### PR TITLE
Ibc client setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@cosmjs/crypto": "0.24.0-alpha.22",
-    "@cosmjs/encoding": "0.24.0-alpha.22",
-    "@cosmjs/math": "0.24.0-alpha.22",
-    "@cosmjs/proto-signing": "0.24.0-alpha.22",
-    "@cosmjs/stargate": "0.24.0-alpha.22",
-    "@cosmjs/tendermint-rpc": "0.24.0-alpha.22",
+    "@cosmjs/crypto": "0.24.0-alpha.23",
+    "@cosmjs/encoding": "0.24.0-alpha.23",
+    "@cosmjs/math": "0.24.0-alpha.23",
+    "@cosmjs/proto-signing": "0.24.0-alpha.23",
+    "@cosmjs/stargate": "0.24.0-alpha.23",
+    "@cosmjs/tendermint-rpc": "0.24.0-alpha.23",
     "@types/node": "^14.14.25",
     "protobufjs": "~6.10.2"
   },

--- a/scripts/wasmd/template/.wasmd/config/genesis.json
+++ b/scripts/wasmd/template/.wasmd/config/genesis.json
@@ -735,7 +735,10 @@
       "client_genesis": {
         "clients": [],
         "clients_consensus": [],
-        "create_localhost": false
+        "create_localhost": false,
+        "params": {
+          "allowed_clients": ["06-solomachine", "07-tendermint"]
+        }
       },
       "connection_genesis": {
         "client_connection_paths": [],
@@ -821,9 +824,7 @@
       "max_bytes": "1048576"
     },
     "validator": {
-      "pub_key_types": [
-        "ed25519"
-      ]
+      "pub_key_types": ["ed25519"]
     },
     "version": {}
   },

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -45,9 +45,7 @@ export class Endpoint {
     _filter?: Filter,
     _minHeight?: number
   ): Promise<Packet[]> {
-    this.client.queryClient.ibc.unverified.connectionChannels(
-      this.connectionID
-    );
+    this.client.query.ibc.unverified.connectionChannels(this.connectionID);
 
     // these all work for one (port, channel).
     // shall we make this general (via filter) or hit up each channel one after another

--- a/src/lib/ibc.spec.ts
+++ b/src/lib/ibc.spec.ts
@@ -9,7 +9,7 @@ import {
   wasmd,
 } from './testutils.spec';
 
-test.only('create simapp client on wasmd', async (t) => {
+test.serial('create simapp client on wasmd', async (t) => {
   // create apps and fund an account
   const mnemonic = generateMnemonic();
   const { client: src } = await signingClient(simapp, mnemonic);
@@ -17,7 +17,7 @@ test.only('create simapp client on wasmd', async (t) => {
   await fundAccount(wasmd, address, '100000');
 
   const preClients = await dest.query.ibc.unverified.clientStates();
-  t.is(preClients.clientStates.length, 0);
+  const preLen = preClients.clientStates.length;
 
   const header = await src.latestHeader();
   const conState = buildConsensusState(header);
@@ -30,5 +30,5 @@ test.only('create simapp client on wasmd', async (t) => {
   await dest.createTendermintClient(address, cliState, conState);
 
   const postClients = await dest.query.ibc.unverified.clientStates();
-  t.is(postClients.clientStates.length, 1);
+  t.is(postClients.clientStates.length, preLen + 1);
 });

--- a/src/lib/ibc.spec.ts
+++ b/src/lib/ibc.spec.ts
@@ -9,7 +9,7 @@ import {
   wasmd,
 } from './testutils.spec';
 
-test.serial('create simapp client on wasmd', async (t) => {
+test.only('create simapp client on wasmd', async (t) => {
   // create apps and fund an account
   const mnemonic = generateMnemonic();
   const { client: src } = await signingClient(simapp, mnemonic);

--- a/src/lib/ibc.spec.ts
+++ b/src/lib/ibc.spec.ts
@@ -1,0 +1,34 @@
+import test from 'ava';
+
+import { buildClientState, buildConsensusState } from './ibcclient';
+import {
+  fundAccount,
+  generateMnemonic,
+  signingClient,
+  simapp,
+  wasmd,
+} from './testutils.spec';
+
+test.serial('create simapp client on wasmd', async (t) => {
+  // create apps and fund an account
+  const mnemonic = generateMnemonic();
+  const { client: src } = await signingClient(simapp, mnemonic);
+  const { address, client: dest } = await signingClient(wasmd, mnemonic);
+  await fundAccount(wasmd, address, '100000');
+
+  const preClients = await dest.query.ibc.unverified.clientStates();
+  t.is(preClients.clientStates.length, 0);
+
+  const header = await src.latestHeader();
+  const conState = buildConsensusState(header);
+  const cliState = buildClientState(
+    await src.getChainId(),
+    1000,
+    500,
+    header.height
+  );
+  await dest.createTendermintClient(address, cliState, conState);
+
+  const postClients = await dest.query.ibc.unverified.clientStates();
+  t.is(postClients.clientStates.length, 1);
+});

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -152,7 +152,7 @@ export class IbcClient {
 
 export function buildConsensusState(header: Header): TendermintConsensusState {
   return TendermintConsensusState.fromPartial({
-    timestamp: new Date(header.time.getMilliseconds()),
+    timestamp: new Date(header.time.getTime()),
     root: {
       hash: header.appHash,
     },

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -11,9 +11,8 @@ import {
   setupAuthExtension,
   setupBankExtension,
   SigningStargateClient,
+  SigningStargateClientOptions,
 } from '@cosmjs/stargate';
-// TODO: this is wrong, expose in top level
-import { SigningStargateClientOptions } from '@cosmjs/stargate/types/signingstargateclient';
 import {
   adaptor34,
   CommitResponse,
@@ -25,7 +24,7 @@ import Long from 'long';
 import { HashOp, LengthOp } from '../codec/confio/proofs';
 import {
   MsgCreateClient,
-  // MsgUpdateClient,
+  MsgUpdateClient,
 } from '../codec/ibc/core/client/v1/tx';
 import {
   ClientState as TendermintClientState,
@@ -37,8 +36,8 @@ import { IbcExtension, setupIbcExtension } from './queries/ibc';
 function ibcRegistry(): Registry {
   return new Registry([
     ...defaultRegistryTypes,
-    // ['/ibc.core.client.v1.MsgCreateClient', MsgCreateClient],
-    // ['/ibc.core.client.v1.MsgUpdateClient', MsgUpdateClient],
+    ['/ibc.core.client.v1.MsgCreateClient', MsgCreateClient],
+    ['/ibc.core.client.v1.MsgUpdateClient', MsgUpdateClient],
   ]);
 }
 

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -21,6 +21,10 @@ import {
   QueryUnreceivedPacketsResponse,
 } from '../../codec/ibc/core/channel/v1/query';
 import {
+  QueryClientImpl as ClientQuery,
+  QueryClientStatesResponse,
+} from '../../codec/ibc/core/client/v1/query';
+import {
   QueryClientImpl as ConnectionQuery,
   QueryClientConnectionsResponse,
   QueryConnectionResponse,
@@ -86,6 +90,7 @@ export interface IbcExtension {
     ) => Promise<number | null>;
     readonly unverified: {
       // Queries for ibc.core.channel.v1
+      readonly clientStates: () => Promise<QueryClientStatesResponse>;
       readonly channel: (
         portId: string,
         channelId: string
@@ -152,6 +157,7 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
   // Use these services to get easy typed access to query methods
   // These cannot be used for proof verification
   const channelQueryService = new ChannelQuery(rpc);
+  const clientQueryService = new ClientQuery(rpc);
   const connectionQueryService = new ConnectionQuery(rpc);
 
   return {
@@ -206,6 +212,9 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
       },
 
       unverified: {
+        clientStates: () => {
+          return clientQueryService.ClientStates({});
+        },
         // Queries for ibc.core.channel.v1
         channel: async (portId: string, channelId: string) => {
           const response = await channelQueryService.Channel({

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -1,14 +1,16 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { toAscii } from '@cosmjs/encoding';
 import { Uint64 } from '@cosmjs/math';
-import { createPagination, createRpc, QueryClient } from '@cosmjs/stargate';
+// TODO: import these when we update
+// import { createPagination, createRpc, QueryClient } from '@cosmjs/stargate';
+import { QueryClient } from '@cosmjs/stargate';
 import Long from 'long';
 
+import { PageRequest } from '../../codec/cosmos/base/query/v1beta1/pagination';
 import { Channel } from '../../codec/ibc/core/channel/v1/channel';
 import {
+  QueryClientImpl as ChannelQuery,
   QueryChannelResponse,
   QueryChannelsResponse,
-  QueryClientImpl as ChannelQuery,
   QueryConnectionChannelsResponse,
   QueryNextSequenceReceiveResponse,
   QueryPacketAcknowledgementResponse,
@@ -19,11 +21,48 @@ import {
   QueryUnreceivedPacketsResponse,
 } from '../../codec/ibc/core/channel/v1/query';
 import {
-  QueryClientConnectionsResponse,
   QueryClientImpl as ConnectionQuery,
+  QueryClientConnectionsResponse,
   QueryConnectionResponse,
   QueryConnectionsResponse,
 } from '../../codec/ibc/core/connection/v1/query';
+
+/*** TODO: remove these: temporary work-around *****/
+export function createPagination(
+  paginationKey?: Uint8Array
+): PageRequest | undefined {
+  return paginationKey
+    ? {
+        key: paginationKey,
+        offset: Long.fromNumber(0, true),
+        limit: Long.fromNumber(0, true),
+        countTotal: false,
+      }
+    : undefined;
+}
+
+export interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array
+  ): Promise<Uint8Array>;
+}
+
+export function createRpc(base: QueryClient): Rpc {
+  return {
+    request: (
+      service: string,
+      method: string,
+      data: Uint8Array
+    ): Promise<Uint8Array> => {
+      const path = `/${service}/${method}`;
+      return base.queryUnverified(path, data);
+    },
+  };
+}
+
+/***** End TODO ******/
 
 export interface IbcExtension {
   readonly ibc: {

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -1,0 +1,307 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { toAscii } from '@cosmjs/encoding';
+import { Uint64 } from '@cosmjs/math';
+import { createPagination, createRpc, QueryClient } from '@cosmjs/stargate';
+import Long from 'long';
+
+import { Channel } from '../../codec/ibc/core/channel/v1/channel';
+import {
+  QueryChannelResponse,
+  QueryChannelsResponse,
+  QueryClientImpl as ChannelQuery,
+  QueryConnectionChannelsResponse,
+  QueryNextSequenceReceiveResponse,
+  QueryPacketAcknowledgementResponse,
+  QueryPacketAcknowledgementsResponse,
+  QueryPacketCommitmentResponse,
+  QueryPacketCommitmentsResponse,
+  QueryUnreceivedAcksResponse,
+  QueryUnreceivedPacketsResponse,
+} from '../../codec/ibc/core/channel/v1/query';
+import {
+  QueryClientConnectionsResponse,
+  QueryClientImpl as ConnectionQuery,
+  QueryConnectionResponse,
+  QueryConnectionsResponse,
+} from '../../codec/ibc/core/connection/v1/query';
+
+export interface IbcExtension {
+  readonly ibc: {
+    readonly channel: (
+      portId: string,
+      channelId: string
+    ) => Promise<Channel | null>;
+    readonly packetCommitment: (
+      portId: string,
+      channelId: string,
+      sequence: number
+    ) => Promise<Uint8Array>;
+    readonly packetAcknowledgement: (
+      portId: string,
+      channelId: string,
+      sequence: number
+    ) => Promise<Uint8Array>;
+    readonly nextSequenceReceive: (
+      portId: string,
+      channelId: string
+    ) => Promise<number | null>;
+    readonly unverified: {
+      // Queries for ibc.core.channel.v1
+      readonly channel: (
+        portId: string,
+        channelId: string
+      ) => Promise<QueryChannelResponse>;
+      readonly channels: (
+        paginationKey?: Uint8Array
+      ) => Promise<QueryChannelsResponse>;
+      readonly connectionChannels: (
+        connection: string,
+        paginationKey?: Uint8Array
+      ) => Promise<QueryConnectionChannelsResponse>;
+      readonly packetCommitment: (
+        portId: string,
+        channelId: string,
+        sequence: number
+      ) => Promise<QueryPacketCommitmentResponse>;
+      readonly packetCommitments: (
+        portId: string,
+        channelId: string,
+        paginationKey?: Uint8Array
+      ) => Promise<QueryPacketCommitmentsResponse>;
+      readonly packetAcknowledgement: (
+        portId: string,
+        channelId: string,
+        sequence: number
+      ) => Promise<QueryPacketAcknowledgementResponse>;
+      readonly packetAcknowledgements: (
+        portId: string,
+        channelId: string,
+        paginationKey?: Uint8Array
+      ) => Promise<QueryPacketAcknowledgementsResponse>;
+      readonly unreceivedPackets: (
+        portId: string,
+        channelId: string,
+        packetCommitmentSequences: readonly number[]
+      ) => Promise<QueryUnreceivedPacketsResponse>;
+      readonly unreceivedAcks: (
+        portId: string,
+        channelId: string,
+        packetCommitmentSequences: readonly number[]
+      ) => Promise<QueryUnreceivedAcksResponse>;
+      readonly nextSequenceReceive: (
+        portId: string,
+        channelId: string
+      ) => Promise<QueryNextSequenceReceiveResponse>;
+
+      // Queries for ibc.core.connection.v1
+
+      readonly connection: (
+        connectionId: string
+      ) => Promise<QueryConnectionResponse>;
+      readonly connections: (
+        paginationKey?: Uint8Array
+      ) => Promise<QueryConnectionsResponse>;
+      readonly clientConnections: (
+        clientId: string
+      ) => Promise<QueryClientConnectionsResponse>;
+    };
+  };
+}
+
+export function setupIbcExtension(base: QueryClient): IbcExtension {
+  const rpc = createRpc(base);
+  // Use these services to get easy typed access to query methods
+  // These cannot be used for proof verification
+  const channelQueryService = new ChannelQuery(rpc);
+  const connectionQueryService = new ConnectionQuery(rpc);
+
+  return {
+    ibc: {
+      channel: async (portId: string, channelId: string) => {
+        // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L55-L65
+        // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L117-L120
+        const key = toAscii(
+          `channelEnds/ports/${portId}/channels/${channelId}`
+        );
+        const responseData = await base.queryVerified('ibc', key);
+        return responseData.length ? Channel.decode(responseData) : null;
+      },
+      packetCommitment: async (
+        portId: string,
+        channelId: string,
+        sequence: number
+      ) => {
+        // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L128-L133
+        // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L183-L185
+        const key = toAscii(
+          `commitments/ports/${portId}/channels/${channelId}/packets/${sequence}`
+        );
+        const responseData = await base.queryVerified('ibc', key);
+        // keeper code doesn't parse, but returns raw
+        return responseData;
+      },
+      packetAcknowledgement: async (
+        portId: string,
+        channelId: string,
+        sequence: number
+      ) => {
+        // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L159-L166
+        // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L153-L156
+        const key = toAscii(
+          `acks/ports/${portId}/channels/${channelId}/acknowledgements/${sequence}`
+        );
+        const responseData = await base.queryVerified('ibc', key);
+        // keeper code doesn't parse, but returns raw
+        return responseData;
+      },
+      nextSequenceReceive: async (portId: string, channelId: string) => {
+        // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L92-L101
+        // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L133-L136
+        const key = toAscii(
+          `seqAcks/ports/${portId}/channels/${channelId}/nextSequenceAck`
+        );
+        const responseData = await base.queryVerified('ibc', key);
+        return responseData.length
+          ? Uint64.fromBytes(responseData).toNumber()
+          : null;
+      },
+
+      unverified: {
+        // Queries for ibc.core.channel.v1
+        channel: async (portId: string, channelId: string) => {
+          const response = await channelQueryService.Channel({
+            portId: portId,
+            channelId: channelId,
+          });
+          return response;
+        },
+        channels: async (paginationKey?: Uint8Array) => {
+          const request = {
+            pagination: createPagination(paginationKey),
+          };
+          const response = await channelQueryService.Channels(request);
+          return response;
+        },
+        connectionChannels: async (
+          connection: string,
+          paginationKey?: Uint8Array
+        ) => {
+          const request = {
+            connection: connection,
+            pagination: createPagination(paginationKey),
+          };
+          const response = await channelQueryService.ConnectionChannels(
+            request
+          );
+          return response;
+        },
+        packetCommitment: async (
+          portId: string,
+          channelId: string,
+          sequence: number
+        ) => {
+          const response = await channelQueryService.PacketCommitment({
+            portId: portId,
+            channelId: channelId,
+            sequence: Long.fromNumber(sequence, true),
+          });
+          return response;
+        },
+        packetCommitments: async (
+          portId: string,
+          channelId: string,
+          paginationKey?: Uint8Array
+        ) => {
+          const request = {
+            channelId: channelId,
+            portId: portId,
+            pagination: createPagination(paginationKey),
+          };
+          const response = await channelQueryService.PacketCommitments(request);
+          return response;
+        },
+        packetAcknowledgement: async (
+          portId: string,
+          channelId: string,
+          sequence: number
+        ) => {
+          const response = await channelQueryService.PacketAcknowledgement({
+            portId: portId,
+            channelId: channelId,
+            sequence: Long.fromNumber(sequence, true),
+          });
+          return response;
+        },
+        packetAcknowledgements: async (
+          portId: string,
+          channelId: string,
+          paginationKey?: Uint8Array
+        ) => {
+          const response = await channelQueryService.PacketAcknowledgements({
+            portId: portId,
+            channelId: channelId,
+            pagination: createPagination(paginationKey),
+          });
+          return response;
+        },
+        unreceivedPackets: async (
+          portId: string,
+          channelId: string,
+          packetCommitmentSequences: readonly number[]
+        ) => {
+          const response = await channelQueryService.UnreceivedPackets({
+            portId: portId,
+            channelId: channelId,
+            packetCommitmentSequences: packetCommitmentSequences.map((s) =>
+              Long.fromNumber(s, true)
+            ),
+          });
+          return response;
+        },
+        unreceivedAcks: async (
+          portId: string,
+          channelId: string,
+          packetAckSequences: readonly number[]
+        ) => {
+          const response = await channelQueryService.UnreceivedAcks({
+            portId: portId,
+            channelId: channelId,
+            packetAckSequences: packetAckSequences.map((s) =>
+              Long.fromNumber(s, true)
+            ),
+          });
+          return response;
+        },
+        nextSequenceReceive: async (portId: string, channelId: string) => {
+          const response = await channelQueryService.NextSequenceReceive({
+            portId: portId,
+            channelId: channelId,
+          });
+          return response;
+        },
+
+        // Queries for ibc.core.connection.v1
+
+        connection: async (connectionId: string) => {
+          const response = await connectionQueryService.Connection({
+            connectionId: connectionId,
+          });
+          return response;
+        },
+        connections: async (paginationKey?: Uint8Array) => {
+          const request = {
+            pagination: createPagination(paginationKey),
+          };
+          const response = await connectionQueryService.Connections(request);
+          return response;
+        },
+        clientConnections: async (clientId: string) => {
+          const response = await connectionQueryService.ClientConnections({
+            clientId: clientId,
+          });
+          return response;
+        },
+      },
+    },
+  };
+}

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -1,11 +1,8 @@
 import { toAscii } from '@cosmjs/encoding';
 import { Uint64 } from '@cosmjs/math';
-// TODO: import these when we update
-// import { createPagination, createRpc, QueryClient } from '@cosmjs/stargate';
-import { QueryClient } from '@cosmjs/stargate';
+import { createPagination, createRpc, QueryClient } from '@cosmjs/stargate';
 import Long from 'long';
 
-import { PageRequest } from '../../codec/cosmos/base/query/v1beta1/pagination';
 import { Channel } from '../../codec/ibc/core/channel/v1/channel';
 import {
   QueryClientImpl as ChannelQuery,
@@ -30,43 +27,6 @@ import {
   QueryConnectionResponse,
   QueryConnectionsResponse,
 } from '../../codec/ibc/core/connection/v1/query';
-
-/*** TODO: remove these: temporary work-around *****/
-export function createPagination(
-  paginationKey?: Uint8Array
-): PageRequest | undefined {
-  return paginationKey
-    ? {
-        key: paginationKey,
-        offset: Long.fromNumber(0, true),
-        limit: Long.fromNumber(0, true),
-        countTotal: false,
-      }
-    : undefined;
-}
-
-export interface Rpc {
-  request(
-    service: string,
-    method: string,
-    data: Uint8Array
-  ): Promise<Uint8Array>;
-}
-
-export function createRpc(base: QueryClient): Rpc {
-  return {
-    request: (
-      service: string,
-      method: string,
-      data: Uint8Array
-    ): Promise<Uint8Array> => {
-      const path = `/${service}/${method}`;
-      return base.queryUnverified(path, data);
-    },
-  };
-}
-
-/***** End TODO ******/
 
 export interface IbcExtension {
   readonly ibc: {

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -3,8 +3,11 @@ import { Bip39, Random } from '@cosmjs/crypto';
 import { Bech32 } from '@cosmjs/encoding';
 import { Decimal } from '@cosmjs/math';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
-import { isBroadcastTxFailure, StargateClient } from '@cosmjs/stargate';
-import { SigningStargateClientOptions } from '@cosmjs/stargate/types/signingstargateclient';
+import {
+  isBroadcastTxFailure,
+  SigningStargateClientOptions,
+  StargateClient,
+} from '@cosmjs/stargate';
 import test from 'ava';
 
 import { IbcClient } from './ibcclient';

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -1,15 +1,13 @@
 // This file outputs some basic test functionality, and includes tests that they work
-import { Random } from '@cosmjs/crypto';
+import { Bip39, Random } from '@cosmjs/crypto';
 import { Bech32 } from '@cosmjs/encoding';
 import { Decimal } from '@cosmjs/math';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
-import {
-  isBroadcastTxFailure,
-  SigningStargateClient,
-  StargateClient,
-} from '@cosmjs/stargate';
+import { isBroadcastTxFailure, StargateClient } from '@cosmjs/stargate';
 import { SigningStargateClientOptions } from '@cosmjs/stargate/types/signingstargateclient';
 import test from 'ava';
+
+import { IbcClient } from './ibcclient';
 
 export const simapp = {
   tendermintUrlWs: 'ws://localhost:26658',
@@ -89,7 +87,7 @@ type FundingOpts = SigningOpts & {
 };
 
 interface SigningInfo {
-  client: SigningStargateClient;
+  client: IbcClient;
   address: string;
 }
 
@@ -114,7 +112,7 @@ export async function signingClient(
       denom: opts.denomFee,
     },
   };
-  const client = await SigningStargateClient.connectWithSigner(
+  const client = await IbcClient.connectWithSigner(
     opts.tendermintUrlHttp,
     signer,
     options
@@ -132,10 +130,14 @@ export async function fundAccount(
     amount,
     denom: opts.denomFee,
   };
-  const resp = await client.sendTokens(address, rcpt, [feeTokens]);
+  const resp = await client.sign.sendTokens(address, rcpt, [feeTokens]);
   if (isBroadcastTxFailure(resp)) {
     throw new Error(`funding failed (${resp.code}) ${resp.rawLog}`);
   }
+}
+
+export function generateMnemonic(): string {
+  return Bip39.encode(Random.getBytes(16)).toString();
 }
 
 export function randomAddress(prefix: string): string {


### PR DESCRIPTION
Closes #6 
- [x] Expose all needed queries from the ibc core modules
- [x] Expose helpers for all needed messages we submit
- [x] Add some basic tests for client creation
- [x] Add helpers to get the merkle proofs from a query (no QueryClient helpers do this now)