### PR TITLE
Support transfer message and relay one packet

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/ibcclient.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -3,15 +3,10 @@ import test from 'ava';
 
 import { Order } from '../codec/ibc/core/channel/v1/channel';
 
-import {
-  buildClientState,
-  buildConsensusState,
-  buildCreateClientArgs,
-  parsePacket,
-  prepareConnectionHandshake,
-} from './ibcclient';
+import { buildCreateClientArgs, prepareConnectionHandshake } from './ibcclient';
 import { Link } from './link';
 import { randomAddress, setup, simapp, wasmd } from './testutils.spec';
+import { buildClientState, buildConsensusState, parsePacket } from './utils';
 
 test.serial('create simapp client on wasmd', async (t) => {
   const [src, dest] = await setup();
@@ -173,16 +168,16 @@ test.serial.only('transfer message and send packets', async (t) => {
   // submit a transfer message
   const destHeight = (await nodeB.latestHeader()).height;
   const token = { amount: '12345', denom: simapp.denomFee };
-  const res = await nodeA.transferTokens(
+  const transferResult = await nodeA.transferTokens(
     channels.src.portId,
     channels.src.channelId,
     token,
     recipient,
     destHeight + 500 // valid for 500 blocks
   );
-  console.log(JSON.stringify(res.logs[0].events, undefined, 2));
+  console.log(JSON.stringify(transferResult.logs[0].events, undefined, 2));
 
-  const packetEvent = res.logs[0].events.find(
+  const packetEvent = transferResult.logs[0].events.find(
     ({ type }) => type === 'send_packet'
   );
   assert(packetEvent);

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -175,7 +175,6 @@ test.serial.only('transfer message and send packets', async (t) => {
     recipient,
     destHeight + 500 // valid for 500 blocks
   );
-  console.log(JSON.stringify(transferResult.logs[0].events, undefined, 2));
 
   const packetEvent = transferResult.logs[0].events.find(
     ({ type }) => type === 'send_packet'
@@ -183,9 +182,11 @@ test.serial.only('transfer message and send packets', async (t) => {
   assert(packetEvent);
   const packet = parsePacket(packetEvent);
   console.log(packet);
-  const proofCommitmentResponse = await nodeA.query.ibc.channel.packetCommitment(
-    channels.src.portId,
-    channels.src.channelId,
+
+  // wait one block before the query, so the data is available
+  const proofCommitmentResponse = await nodeA.query.ibc.proof.channel.packetCommitment(
+    packet.sourcePort,
+    packet.sourceChannel,
     packet.sequence.toNumber()
   );
   console.log('PROOF COMMITMENT QUERY RESPONSE', proofCommitmentResponse);
@@ -193,7 +194,7 @@ test.serial.only('transfer message and send packets', async (t) => {
   await nodeB.doUpdateClient(link.endB.clientID, nodeA);
   const relayResult = await nodeB.receivePacket(
     packet,
-    proofCommitmentResponse.commitment,
+    proofCommitmentResponse.proof,
     proofCommitmentResponse.proofHeight
   );
   console.log(relayResult);

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -183,8 +183,20 @@ test.serial.only('transfer message and send packets', async (t) => {
   assert(packetEvent);
   const packet = parsePacket(packetEvent);
   console.log(packet);
+  const proofCommitmentResponse = await nodeA.query.ibc.channel.packetCommitment(
+    channels.src.portId,
+    channels.src.channelId,
+    packet.sequence.toNumber()
+  );
+  console.log('PROOF COMMITMENT QUERY RESPONSE', proofCommitmentResponse);
 
-  // TODO: relay packet
+  await nodeB.doUpdateClient(link.endB.clientID, nodeA);
+  const relayResult = await nodeB.receivePacket(
+    packet,
+    proofCommitmentResponse.commitment,
+    proofCommitmentResponse.proofHeight
+  );
+  console.log(relayResult);
 
   // TODO: query balance of recipient (should be "12345" or some odd hash...)
 

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -1,4 +1,4 @@
-import { toAscii, toUtf8 } from '@cosmjs/encoding';
+import { toAscii } from '@cosmjs/encoding';
 import {
   buildFeeTable,
   Coin,
@@ -12,7 +12,6 @@ import { OfflineSigner, Registry } from '@cosmjs/proto-signing';
 import {
   AuthExtension,
   BankExtension,
-  BroadcastTxFailure,
   BroadcastTxResponse,
   defaultRegistryTypes,
   isBroadcastTxFailure,
@@ -26,19 +25,15 @@ import {
 import {
   adaptor34,
   CommitResponse,
-  ReadonlyDateWithNanoseconds,
   Header as RpcHeader,
-  ValidatorPubkey as RpcPubKey,
   Client as TendermintClient,
 } from '@cosmjs/tendermint-rpc';
 import { arrayContentEquals, sleep } from '@cosmjs/utils';
 import Long from 'long';
 
-import { HashOp, LengthOp } from '../codec/confio/proofs';
 import { Any } from '../codec/google/protobuf/any';
-import { Timestamp } from '../codec/google/protobuf/timestamp';
 import { MsgTransfer } from '../codec/ibc/applications/transfer/v1/tx';
-import { Order, Packet, State } from '../codec/ibc/core/channel/v1/channel';
+import { Order, State } from '../codec/ibc/core/channel/v1/channel';
 import {
   MsgChannelOpenAck,
   MsgChannelOpenConfirm,
@@ -62,7 +57,6 @@ import {
   ConsensusState as TendermintConsensusState,
   Header as TendermintHeader,
 } from '../codec/ibc/lightclients/tendermint/v1/tendermint';
-import { PublicKey as ProtoPubKey } from '../codec/tendermint/crypto/keys';
 import {
   blockIDFlagFromJSON,
   Commit,
@@ -72,6 +66,15 @@ import {
 import { ValidatorSet } from '../codec/tendermint/types/validator';
 
 import { IbcExtension, setupIbcExtension } from './queries/ibc';
+import {
+  buildClientState,
+  buildConsensusState,
+  createBroadcastTxErrorMessage,
+  mapRpcPubKeyToProto,
+  timestampFromDateNanos,
+  toIntHeight,
+  toProtoHeight,
+} from './utils';
 
 /**** These are needed to bootstrap the endpoints */
 /* Some of them are hardcoded various places, which should we make configurable? */
@@ -110,24 +113,6 @@ function ibcRegistry(): Registry {
     ['/ibc.core.channel.v1.MsgChannelOpenConfirm', MsgChannelOpenConfirm],
     ['/ibc.applications.transfer.v1.MsgTransfer', MsgTransfer],
   ]);
-}
-
-function timestampFromDateNanos(date: ReadonlyDateWithNanoseconds): Timestamp {
-  const nanos = (date.getTime() % 1000) * 1000000 + (date.nanoseconds ?? 0);
-  return Timestamp.fromPartial({
-    seconds: new Long(date.getTime() / 1000),
-    nanos,
-  });
-}
-
-export function toIntHeight(height?: Height): number {
-  return height?.revisionHeight?.toNumber() ?? 0;
-}
-
-export function toProtoHeight(height: number): Height {
-  return Height.fromPartial({
-    revisionHeight: new Long(height),
-  });
 }
 
 /// This is the default message result with no extra data
@@ -174,10 +159,6 @@ export interface ChannelHandshake {
 export interface ChannelInfo {
   readonly portId: string;
   readonly channelId: string;
-}
-
-function createBroadcastTxErrorMessage(result: BroadcastTxFailure): string {
-  return `Error when broadcasting tx ${result.transactionHash} at height ${result.height}. Code: ${result.code}; Raw log: ${result.rawLog}`;
 }
 
 export interface IbcFeeTable extends FeeTable {
@@ -941,25 +922,6 @@ export class IbcClient {
   }
 }
 
-function mapRpcPubKeyToProto(pubkey?: RpcPubKey): ProtoPubKey | undefined {
-  if (pubkey === undefined) {
-    return undefined;
-  }
-  if (pubkey.algorithm == 'ed25519') {
-    return {
-      ed25519: pubkey.data,
-      secp256k1: undefined,
-    };
-  } else if (pubkey.algorithm == 'secp256k1') {
-    return {
-      ed25519: undefined,
-      secp256k1: pubkey.data,
-    };
-  } else {
-    throw new Error(`Unknown validator pubkey type: ${pubkey.algorithm}`);
-  }
-}
-
 export interface CreateClientArgs {
   clientState: TendermintClientState;
   consensusState: TendermintConsensusState;
@@ -979,86 +941,6 @@ export async function buildCreateClientArgs(
     header.height
   );
   return { consensusState, clientState };
-}
-
-export function buildConsensusState(
-  header: RpcHeader
-): TendermintConsensusState {
-  return TendermintConsensusState.fromPartial({
-    timestamp: timestampFromDateNanos(header.time),
-    root: {
-      hash: header.appHash,
-    },
-    nextValidatorsHash: header.nextValidatorsHash,
-  });
-}
-
-// Note: we hardcode a number of assumptions, like trust level, clock drift, and assume revisionNumber is 1
-export function buildClientState(
-  chainId: string,
-  unbondingPeriodSec: number,
-  trustPeriodSec: number,
-  height: number
-): TendermintClientState {
-  // Copied here until https://github.com/confio/ics23/issues/36 is resolved
-  // https://github.com/confio/ics23/blob/master/js/src/proofs.ts#L11-L26
-  const iavlSpec = {
-    leafSpec: {
-      prefix: Uint8Array.from([0]),
-      hash: HashOp.SHA256,
-      prehashValue: HashOp.SHA256,
-      prehashKey: HashOp.NO_HASH,
-      length: LengthOp.VAR_PROTO,
-    },
-    innerSpec: {
-      childOrder: [0, 1],
-      minPrefixLength: 4,
-      maxPrefixLength: 12,
-      childSize: 33,
-      hash: HashOp.SHA256,
-    },
-  };
-  const tendermintSpec = {
-    leafSpec: {
-      prefix: Uint8Array.from([0]),
-      hash: HashOp.SHA256,
-      prehashValue: HashOp.SHA256,
-      prehashKey: HashOp.NO_HASH,
-      length: LengthOp.VAR_PROTO,
-    },
-    innerSpec: {
-      childOrder: [0, 1],
-      minPrefixLength: 1,
-      maxPrefixLength: 1,
-      childSize: 32,
-      hash: HashOp.SHA256,
-    },
-  };
-
-  return TendermintClientState.fromPartial({
-    chainId,
-    trustLevel: {
-      numerator: Long.fromInt(1),
-      denominator: Long.fromInt(3),
-    },
-    unbondingPeriod: {
-      seconds: new Long(unbondingPeriodSec),
-    },
-    trustingPeriod: {
-      seconds: new Long(trustPeriodSec),
-    },
-    maxClockDrift: {
-      seconds: new Long(20),
-    },
-    latestHeight: {
-      revisionNumber: new Long(0), // ??
-      revisionHeight: new Long(height),
-    },
-    proofSpecs: [iavlSpec, tendermintSpec],
-    upgradePath: ['upgrade', 'upgradedIBCState'],
-    allowUpdateAfterExpiry: false,
-    allowUpdateAfterMisbehaviour: false,
-  });
 }
 
 export async function prepareConnectionHandshake(
@@ -1095,56 +977,4 @@ export async function prepareChannelHandshake(
   // get a proof (for the proven height)
   const proof = await src.getChannelProof({ portId, channelId }, headerHeight);
   return proof;
-}
-
-interface ParsedAttribute {
-  readonly key: string;
-  readonly value: string;
-}
-
-export interface ParsedEvent {
-  readonly type: string;
-  readonly attributes: readonly ParsedAttribute[];
-}
-
-export function parsePacket({ type, attributes }: ParsedEvent): Packet {
-  if (type !== 'send_packet') {
-    throw new Error(`Cannot parse event of type ${type}`);
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const attributesObj: any = attributes.reduce(
-    (acc, { key, value }) => ({
-      ...acc,
-      [key]: value,
-    }),
-    {}
-  );
-  const [timeoutRevisionNumber, timeoutRevisionHeight] =
-    attributesObj.packet_timeout_height?.split('-') ?? [];
-  return {
-    sequence: Long.fromNumber(attributesObj.packet_sequence ?? 0, true),
-    /** identifies the port on the sending chain. */
-    sourcePort: attributesObj.packet_src_port ?? '',
-    /** identifies the channel end on the sending chain. */
-    sourceChannel: attributesObj.packet_src_channel ?? '',
-    /** identifies the port on the receiving chain. */
-    destinationPort: attributesObj.packet_dst_port ?? '',
-    /** identifies the channel end on the receiving chain. */
-    destinationChannel: attributesObj.packet_dst_channel ?? '',
-    /** actual opaque bytes transferred directly to the application module */
-    data: toUtf8(attributesObj.packet_data ?? ''),
-    /** block height after which the packet times out */
-    timeoutHeight:
-      timeoutRevisionNumber && timeoutRevisionHeight
-        ? Height.fromPartial({
-            revisionNumber: timeoutRevisionNumber,
-            revisionHeight: timeoutRevisionHeight,
-          })
-        : undefined,
-    /** block timestamp (in nanoseconds) after which the packet times out */
-    timeoutTimestamp: Long.fromString(
-      attributesObj.packet_timeout_timestamp ?? '0',
-      true
-    ),
-  };
 }

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -948,7 +948,6 @@ export class IbcClient {
     if (isBroadcastTxFailure(result)) {
       throw new Error(createBroadcastTxErrorMessage(result));
     }
-    console.log('RESULT', result);
     const parsedLogs = parseRawLog(result.rawLog);
     return {
       logs: parsedLogs,

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -186,7 +186,7 @@ const defaultGasLimits: GasLimits<IbcFeeTable> = {
   connectionHandshake: 200000,
   initChannel: 100000,
   channelHandshake: 200000,
-  receivePacket: 100000,
+  receivePacket: 200000,
   transfer: 120000,
 };
 

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -440,6 +440,22 @@ export class IbcClient {
     };
   }
 
+  public async getPacketProof(
+    packet: Packet,
+    headerHeight: number
+  ): Promise<Uint8Array> {
+    const queryHeight = headerHeight - 1;
+
+    const { proof } = await this.query.ibc.proof.channel.packetCommitment(
+      packet.sourcePort,
+      packet.sourceChannel,
+      packet.sequence.toNumber(),
+      queryHeight
+    );
+
+    return proof;
+  }
+
   /*
   These are helpers to query, build data and submit a message
   Currently all prefixed with doXxx, but please look for better naming

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -184,16 +184,19 @@ export interface IbcExtension {
         readonly packetCommitment: (
           portId: string,
           channelId: string,
-          sequence: number
+          sequence: number,
+          proveHeight?: number
         ) => Promise<QueryPacketCommitmentResponse>;
         readonly packetAcknowledgement: (
           portId: string,
           channelId: string,
-          sequence: number
+          sequence: number,
+          proveHeight?: number
         ) => Promise<QueryPacketAcknowledgementResponse>;
         readonly nextSequenceReceive: (
           portId: string,
-          channelId: string
+          channelId: string,
+          proveHeight?: number
         ) => Promise<QueryNextSequenceReceiveResponse>;
       };
       readonly client: {
@@ -566,12 +569,13 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
           packetCommitment: async (
             portId: string,
             channelId: string,
-            sequence: number
+            sequence: number,
+            proveHeight?: number
           ) => {
             const key = toAscii(
               `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence}`
             );
-            const proven = await base.queryRawProof('ibc', key);
+            const proven = await base.queryRawProof('ibc', key, proveHeight);
             const commitment = proven.value;
             const proof = convertProofsToIcs23(proven.proof);
             const proofHeight = Height.fromPartial({
@@ -586,12 +590,13 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
           packetAcknowledgement: async (
             portId: string,
             channelId: string,
-            sequence: number
+            sequence: number,
+            proveHeight?: number
           ) => {
             const key = toAscii(
               `acks/ports/${portId}/channels/${channelId}/sequences/${sequence}`
             );
-            const proven = await base.queryRawProof('ibc', key);
+            const proven = await base.queryRawProof('ibc', key, proveHeight);
             const acknowledgement = proven.value;
             const proof = convertProofsToIcs23(proven.proof);
             const proofHeight = Height.fromPartial({
@@ -603,11 +608,15 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
               proofHeight: proofHeight,
             };
           },
-          nextSequenceReceive: async (portId: string, channelId: string) => {
+          nextSequenceReceive: async (
+            portId: string,
+            channelId: string,
+            proveHeight?: number
+          ) => {
             const key = toAscii(
               `nextSequenceRecv/ports/${portId}/channels/${channelId}`
             );
-            const proven = await base.queryRawProof('ibc', key);
+            const proven = await base.queryRawProof('ibc', key, proveHeight);
             const nextSequenceReceive = Long.fromBytesBE([...proven.value]);
             const proof = convertProofsToIcs23(proven.proof);
             const proofHeight = Height.fromPartial({

--- a/src/lib/queries/ibc.ts
+++ b/src/lib/queries/ibc.ts
@@ -539,6 +539,8 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
           ),
       },
       proof: {
+        // these keys can all be found here: https://github.com/cosmos/cosmos-sdk/blob/v0.41.1/x/ibc/core/24-host/keys.go
+        // note some have changed since the v0.40 pre-release this code was based on
         channel: {
           channel: async (
             portId: string,
@@ -566,9 +568,8 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
             channelId: string,
             sequence: number
           ) => {
-            // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L183-L185
             const key = toAscii(
-              `commitments/ports/${portId}/channels/${channelId}/packets/${sequence}`
+              `commitments/ports/${portId}/channels/${channelId}/sequences/${sequence}`
             );
             const proven = await base.queryRawProof('ibc', key);
             const commitment = proven.value;
@@ -587,10 +588,8 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
             channelId: string,
             sequence: number
           ) => {
-            // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L159-L166
-            // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L153-L156
             const key = toAscii(
-              `acks/ports/${portId}/channels/${channelId}/acknowledgements/${sequence}`
+              `acks/ports/${portId}/channels/${channelId}/sequences/${sequence}`
             );
             const proven = await base.queryRawProof('ibc', key);
             const acknowledgement = proven.value;
@@ -605,10 +604,8 @@ export function setupIbcExtension(base: QueryClient): IbcExtension {
             };
           },
           nextSequenceReceive: async (portId: string, channelId: string) => {
-            // keeper: https://github.com/cosmos/cosmos-sdk/blob/3bafd8255a502e5a9cee07391cf8261538245dfd/x/ibc/04-channel/keeper/keeper.go#L92-L101
-            // key: https://github.com/cosmos/cosmos-sdk/blob/ef0a7344af345882729598bc2958a21143930a6b/x/ibc/24-host/keys.go#L133-L136
             const key = toAscii(
-              `seqAcks/ports/${portId}/channels/${channelId}/nextSequenceAck`
+              `nextSequenceRecv/ports/${portId}/channels/${channelId}`
             );
             const proven = await base.queryRawProof('ibc', key);
             const nextSequenceReceive = Long.fromBytesBE([...proven.value]);

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -3,7 +3,7 @@ import { Bip39, Random } from '@cosmjs/crypto';
 import { Bech32 } from '@cosmjs/encoding';
 import { Decimal } from '@cosmjs/math';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
-import { isBroadcastTxFailure, StargateClient } from '@cosmjs/stargate';
+import { StargateClient } from '@cosmjs/stargate';
 import test from 'ava';
 
 import { IbcClient, IbcClientOptions } from './ibcclient';
@@ -135,10 +135,7 @@ export async function fundAccount(
     amount,
     denom: opts.denomFee,
   };
-  const resp = await client.sendTokens(rcpt, [feeTokens]);
-  if (isBroadcastTxFailure(resp)) {
-    throw new Error(`funding failed (${resp.code}) ${resp.rawLog}`);
-  }
+  await client.sendTokens(rcpt, [feeTokens]);
 }
 
 export function generateMnemonic(): string {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { toUtf8 } from '@cosmjs/encoding';
+import { logs } from '@cosmjs/launchpad';
 import { BroadcastTxFailure } from '@cosmjs/stargate';
 import {
   ReadonlyDateWithNanoseconds,
@@ -152,6 +153,15 @@ interface ParsedAttribute {
 interface ParsedEvent {
   readonly type: string;
   readonly attributes: readonly ParsedAttribute[];
+}
+
+export function parsePacketsFromLogs(logs: readonly logs.Log[]): Packet[] {
+  // grab all send_packet events from the logs
+  const allEvents: ParsedEvent[][] = logs.map((log) =>
+    log.events.filter(({ type }) => type === 'send_packet')
+  );
+  const flatEvents = ([] as ParsedEvent[]).concat(...allEvents);
+  return flatEvents.map(parsePacket);
 }
 
 export function parsePacket({ type, attributes }: ParsedEvent): Packet {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,197 @@
+import { toUtf8 } from '@cosmjs/encoding';
+import { BroadcastTxFailure } from '@cosmjs/stargate';
+import {
+  ReadonlyDateWithNanoseconds,
+  Header as RpcHeader,
+  ValidatorPubkey as RpcPubKey,
+} from '@cosmjs/tendermint-rpc';
+import Long from 'long';
+
+import { HashOp, LengthOp } from '../codec/confio/proofs';
+import { Timestamp } from '../codec/google/protobuf/timestamp';
+import { Packet } from '../codec/ibc/core/channel/v1/channel';
+import { Height } from '../codec/ibc/core/client/v1/client';
+import {
+  ClientState as TendermintClientState,
+  ConsensusState as TendermintConsensusState,
+} from '../codec/ibc/lightclients/tendermint/v1/tendermint';
+import { PublicKey as ProtoPubKey } from '../codec/tendermint/crypto/keys';
+
+export function createBroadcastTxErrorMessage(
+  result: BroadcastTxFailure
+): string {
+  return `Error when broadcasting tx ${result.transactionHash} at height ${result.height}. Code: ${result.code}; Raw log: ${result.rawLog}`;
+}
+
+export function toIntHeight(height?: Height): number {
+  return height?.revisionHeight?.toNumber() ?? 0;
+}
+
+export function toProtoHeight(height: number): Height {
+  return Height.fromPartial({
+    revisionHeight: new Long(height),
+  });
+}
+
+export function mapRpcPubKeyToProto(
+  pubkey?: RpcPubKey
+): ProtoPubKey | undefined {
+  if (pubkey === undefined) {
+    return undefined;
+  }
+  if (pubkey.algorithm == 'ed25519') {
+    return {
+      ed25519: pubkey.data,
+      secp256k1: undefined,
+    };
+  } else if (pubkey.algorithm == 'secp256k1') {
+    return {
+      ed25519: undefined,
+      secp256k1: pubkey.data,
+    };
+  } else {
+    throw new Error(`Unknown validator pubkey type: ${pubkey.algorithm}`);
+  }
+}
+
+export function timestampFromDateNanos(
+  date: ReadonlyDateWithNanoseconds
+): Timestamp {
+  const nanos = (date.getTime() % 1000) * 1000000 + (date.nanoseconds ?? 0);
+  return Timestamp.fromPartial({
+    seconds: new Long(date.getTime() / 1000),
+    nanos,
+  });
+}
+
+export function buildConsensusState(
+  header: RpcHeader
+): TendermintConsensusState {
+  return TendermintConsensusState.fromPartial({
+    timestamp: timestampFromDateNanos(header.time),
+    root: {
+      hash: header.appHash,
+    },
+    nextValidatorsHash: header.nextValidatorsHash,
+  });
+}
+
+// Note: we hardcode a number of assumptions, like trust level, clock drift, and assume revisionNumber is 1
+export function buildClientState(
+  chainId: string,
+  unbondingPeriodSec: number,
+  trustPeriodSec: number,
+  height: number
+): TendermintClientState {
+  // Copied here until https://github.com/confio/ics23/issues/36 is resolved
+  // https://github.com/confio/ics23/blob/master/js/src/proofs.ts#L11-L26
+  const iavlSpec = {
+    leafSpec: {
+      prefix: Uint8Array.from([0]),
+      hash: HashOp.SHA256,
+      prehashValue: HashOp.SHA256,
+      prehashKey: HashOp.NO_HASH,
+      length: LengthOp.VAR_PROTO,
+    },
+    innerSpec: {
+      childOrder: [0, 1],
+      minPrefixLength: 4,
+      maxPrefixLength: 12,
+      childSize: 33,
+      hash: HashOp.SHA256,
+    },
+  };
+  const tendermintSpec = {
+    leafSpec: {
+      prefix: Uint8Array.from([0]),
+      hash: HashOp.SHA256,
+      prehashValue: HashOp.SHA256,
+      prehashKey: HashOp.NO_HASH,
+      length: LengthOp.VAR_PROTO,
+    },
+    innerSpec: {
+      childOrder: [0, 1],
+      minPrefixLength: 1,
+      maxPrefixLength: 1,
+      childSize: 32,
+      hash: HashOp.SHA256,
+    },
+  };
+
+  return TendermintClientState.fromPartial({
+    chainId,
+    trustLevel: {
+      numerator: Long.fromInt(1),
+      denominator: Long.fromInt(3),
+    },
+    unbondingPeriod: {
+      seconds: new Long(unbondingPeriodSec),
+    },
+    trustingPeriod: {
+      seconds: new Long(trustPeriodSec),
+    },
+    maxClockDrift: {
+      seconds: new Long(20),
+    },
+    latestHeight: {
+      revisionNumber: new Long(0), // ??
+      revisionHeight: new Long(height),
+    },
+    proofSpecs: [iavlSpec, tendermintSpec],
+    upgradePath: ['upgrade', 'upgradedIBCState'],
+    allowUpdateAfterExpiry: false,
+    allowUpdateAfterMisbehaviour: false,
+  });
+}
+
+interface ParsedAttribute {
+  readonly key: string;
+  readonly value: string;
+}
+
+interface ParsedEvent {
+  readonly type: string;
+  readonly attributes: readonly ParsedAttribute[];
+}
+
+export function parsePacket({ type, attributes }: ParsedEvent): Packet {
+  if (type !== 'send_packet') {
+    throw new Error(`Cannot parse event of type ${type}`);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const attributesObj: any = attributes.reduce(
+    (acc, { key, value }) => ({
+      ...acc,
+      [key]: value,
+    }),
+    {}
+  );
+  const [timeoutRevisionNumber, timeoutRevisionHeight] =
+    attributesObj.packet_timeout_height?.split('-') ?? [];
+  return {
+    sequence: Long.fromNumber(attributesObj.packet_sequence ?? 0, true),
+    /** identifies the port on the sending chain. */
+    sourcePort: attributesObj.packet_src_port ?? '',
+    /** identifies the channel end on the sending chain. */
+    sourceChannel: attributesObj.packet_src_channel ?? '',
+    /** identifies the port on the receiving chain. */
+    destinationPort: attributesObj.packet_dst_port ?? '',
+    /** identifies the channel end on the receiving chain. */
+    destinationChannel: attributesObj.packet_dst_channel ?? '',
+    /** actual opaque bytes transferred directly to the application module */
+    data: toUtf8(attributesObj.packet_data ?? ''),
+    /** block height after which the packet times out */
+    timeoutHeight:
+      timeoutRevisionNumber && timeoutRevisionHeight
+        ? Height.fromPartial({
+            revisionNumber: timeoutRevisionNumber,
+            revisionHeight: timeoutRevisionHeight,
+          })
+        : undefined,
+    /** block timestamp (in nanoseconds) after which the packet times out */
+    timeoutTimestamp: Long.fromString(
+      attributesObj.packet_timeout_timestamp ?? '0',
+      true
+    ),
+  };
+}


### PR DESCRIPTION
Closes #34 

IbcClient:

- [x] Add support for ibc-transfer Msg (to start send)
- [x] Add support to parse all packets from tx logs
- [x] Add support for sendPacket Msg (to submit on other side)

Test cases:

- [x] Submit normal token send msg, parse events, 0 packets
- [x] Submit IBC token transfer, parse events, 1 packet
- [x] Submit 3 msg tx - 1 send, 2 ibc transfer, 2 packets
- [x] Take parsed packets (above), submit to remote chain with `updateClient` and matching proofs. Ensure success and check receiver balance on remote chain

So far, I added MsgTransfer support and a simple test that starts this process. You can run `yarn focused-test` to just run that one test case over and over (faster dev cycle). Once the happy path works, it would be good to add more parsing tests. Especially the multi-msg case is important (this came up in the ibc relayer call last night)