### PR TITLE
Implement Link.createWithExistingConnections

### DIFF
--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -61,6 +61,19 @@ test.serial('errors when reusing an invalid connection', async (t) => {
   );
 });
 
+test.serial(`errors when reusing connections which don’t match`, async (t) => {
+  const [src, dest] = await setup();
+
+  const oldLink1 = await Link.createWithNewConnections(src, dest);
+  const connA = oldLink1.endA.connectionID;
+  const oldLink2 = await Link.createWithNewConnections(src, dest);
+  const connB = oldLink2.endB.connectionID;
+
+  await t.throwsAsync(() =>
+    Link.createWithExistingConnections(src, dest, connA, connB)
+  );
+});
+
 // constants for this transport protocol
 const ics20 = {
   // we set a new port in genesis for simapp

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -153,15 +153,15 @@ test.serial('reuse existing connections', async (t) => {
   t.is(channelDest.channel?.counterparty?.channelId, oldChannels.src.channelId);
 
   // Check everything is fine by creating a new channel
-  // TODO: Why does this fail with this error?
-  // failed to execute message; message index: 0: channel handshake open try failed: failed channel state verification for client (07-tendermint-42): client state height < proof height ({0 17506} < {0 17512}): invalid height
-  // await newLink.createChannel(
-  //   'A',
-  //   ics20.srcPortId,
-  //   ics20.destPortId,
-  //   ics20.ordering,
-  //   ics20.version
-  // );
+  // switch src and dest just to test another path
+  const newChannels = await newLink.createChannel(
+    'B',
+    ics20.destPortId,
+    ics20.srcPortId,
+    ics20.ordering,
+    ics20.version
+  );
+  t.notDeepEqual(newChannels.dest, oldChannels.src);
 });
 
 test.serial('errors when reusing an invalid connection', async (t) => {

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -20,6 +20,47 @@ test.serial('establish new client-connection', async (t) => {
   // TODO: ensure it is updated
 });
 
+test.serial('reuse existing connections', async (t) => {
+  const [src, dest] = await setup();
+
+  const oldLink = await Link.createWithNewConnections(src, dest);
+  const connA = oldLink.endA.connectionID;
+  const connB = oldLink.endB.connectionID;
+
+  const newLink = await Link.createWithExistingConnections(
+    src,
+    dest,
+    connA,
+    connB
+  );
+
+  // ensure the data makes sense (TODO: more?)
+  t.assert(
+    newLink.endA.clientID.startsWith('07-tendermint-'),
+    newLink.endA.clientID
+  );
+  t.assert(
+    newLink.endB.clientID.startsWith('07-tendermint-'),
+    newLink.endB.clientID
+  );
+
+  // try to update both clients, ensuring this connection is stable
+  await newLink.updateClient('A');
+  // TODO: ensure it is updated
+  await newLink.updateClient('B');
+  // TODO: ensure it is updated
+});
+
+test.serial('errors when reusing an invalid connection', async (t) => {
+  const [src, dest] = await setup();
+
+  const connA = 'whatever';
+  const connB = 'unreal';
+  await t.throwsAsync(() =>
+    Link.createWithExistingConnections(src, dest, connA, connB)
+  );
+});
+
 // constants for this transport protocol
 const ics20 = {
   // we set a new port in genesis for simapp

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -74,6 +74,22 @@ export class Link {
         `Client ID ${connectionB.clientId} for connection with ID ${connB} does not match counterparty client ID ${connectionA.counterparty.clientId} for connection with ID ${connA}`
       );
     }
+    const [chainIdA, chainIdB, clientStateA, clientStateB] = await Promise.all([
+      nodeA.getChainId(),
+      nodeB.getChainId(),
+      nodeA.query.ibc.client.stateTm(connectionA.clientId),
+      nodeB.query.ibc.client.stateTm(connectionB.clientId),
+    ]);
+    if (chainIdA !== clientStateB.chainId) {
+      throw new Error(
+        `Chain ID ${chainIdA} for connection with ID ${connA} does not match remote chain ID ${clientStateA.chainId}`
+      );
+    }
+    if (chainIdB !== clientStateA.chainId) {
+      throw new Error(
+        `Chain ID ${chainIdB} for connection with ID ${connB} does not match remote chain ID ${clientStateB.chainId}`
+      );
+    }
     const endA = new Endpoint(nodeA, clientIdA, connA);
     const endB = new Endpoint(nodeB, clientIdB, connB);
     return new Link(endA, endB);

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -44,7 +44,6 @@ export class Link {
     connA: string,
     connB: string
   ): Promise<Link> {
-    const [clientIdA, clientIdB] = await createClients(nodeA, nodeB);
     const [
       { connection: connectionA },
       { connection: connectionB },
@@ -64,12 +63,14 @@ export class Link {
     if (!connectionB.counterparty) {
       throw new Error(`Counterparty not found for connection with ID ${connB}`);
     }
-    if (connectionA.clientId !== connectionB.counterparty.clientId) {
+
+    const [clientIdA, clientIdB] = [connectionA.clientId, connectionB.clientId];
+    if (clientIdA !== connectionB.counterparty.clientId) {
       throw new Error(
         `Client ID ${connectionA.clientId} for connection with ID ${connA} does not match counterparty client ID ${connectionB.counterparty.clientId} for connection with ID ${connB}`
       );
     }
-    if (connectionB.clientId !== connectionA.counterparty.clientId) {
+    if (clientIdB !== connectionA.counterparty.clientId) {
       throw new Error(
         `Client ID ${connectionB.clientId} for connection with ID ${connB} does not match counterparty client ID ${connectionA.counterparty.clientId} for connection with ID ${connA}`
       );
@@ -77,8 +78,8 @@ export class Link {
     const [chainIdA, chainIdB, clientStateA, clientStateB] = await Promise.all([
       nodeA.getChainId(),
       nodeB.getChainId(),
-      nodeA.query.ibc.client.stateTm(connectionA.clientId),
-      nodeB.query.ibc.client.stateTm(connectionB.clientId),
+      nodeA.query.ibc.client.stateTm(clientIdA),
+      nodeB.query.ibc.client.stateTm(clientIdB),
     ]);
     if (chainIdA !== clientStateB.chainId) {
       throw new Error(

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -90,6 +90,7 @@ export class Link {
         `Chain ID ${chainIdB} for connection with ID ${connB} does not match remote chain ID ${clientStateB.chainId}`
       );
     }
+    // TODO: Check headers match consensus state
     const endA = new Endpoint(nodeA, clientIdA, connA);
     const endB = new Endpoint(nodeB, clientIdB, connB);
     return new Link(endA, endB);

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -45,15 +45,34 @@ export class Link {
     connB: string
   ): Promise<Link> {
     const [clientIdA, clientIdB] = await createClients(nodeA, nodeB);
-    const [connectionResponseA, connectionResponseB] = await Promise.all([
+    const [
+      { connection: connectionA },
+      { connection: connectionB },
+    ] = await Promise.all([
       nodeA.query.ibc.connection.connection(connA),
       nodeB.query.ibc.connection.connection(connB),
     ]);
-    if (!connectionResponseA.connection) {
-      throw new Error(`Connection not found for connection ID ${connA}`);
+    if (!connectionA) {
+      throw new Error(`Connection not found for ID ${connA}`);
     }
-    if (!connectionResponseB.connection) {
-      throw new Error(`Connection not found for connection ID ${connB}`);
+    if (!connectionB) {
+      throw new Error(`Connection not found for ID ${connB}`);
+    }
+    if (!connectionA.counterparty) {
+      throw new Error(`Counterparty not found for connection with ID ${connA}`);
+    }
+    if (!connectionB.counterparty) {
+      throw new Error(`Counterparty not found for connection with ID ${connB}`);
+    }
+    if (connectionA.clientId !== connectionB.counterparty.clientId) {
+      throw new Error(
+        `Client ID ${connectionA.clientId} for connection with ID ${connA} does not match counterparty client ID ${connectionB.counterparty.clientId} for connection with ID ${connB}`
+      );
+    }
+    if (connectionB.clientId !== connectionA.counterparty.clientId) {
+      throw new Error(
+        `Client ID ${connectionB.clientId} for connection with ID ${connB} does not match counterparty client ID ${connectionA.counterparty.clientId} for connection with ID ${connA}`
+      );
     }
     const endA = new Endpoint(nodeA, clientIdA, connA);
     const endB = new Endpoint(nodeB, clientIdB, connB);

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -44,10 +44,20 @@ export class Link {
     connA: string,
     connB: string
   ): Promise<Link> {
-    // so they are no marked unused variables
-    [nodeA, nodeB, connA, connB];
-
-    throw new Error('not yet implemented');
+    const [clientIdA, clientIdB] = await createClients(nodeA, nodeB);
+    const [connectionResponseA, connectionResponseB] = await Promise.all([
+      nodeA.query.ibc.connection.connection(connA),
+      nodeB.query.ibc.connection.connection(connB),
+    ]);
+    if (!connectionResponseA.connection) {
+      throw new Error(`Connection not found for connection ID ${connA}`);
+    }
+    if (!connectionResponseB.connection) {
+      throw new Error(`Connection not found for connection ID ${connB}`);
+    }
+    const endA = new Endpoint(nodeA, clientIdA, connA);
+    const endB = new Endpoint(nodeB, clientIdB, connB);
+    return new Link(endA, endB);
   }
 
   /**


### PR DESCRIPTION
Part 1 of #18

Still to do:

- add check in `Link.createWithExistingConnections` that header matches consensus state
- test for `Link.createWithExistingConnections` with partially open channel on existing connection