### PR TITLE
Bump to wasmd 0.15.1, simapp 0.41.3

### DIFF
--- a/scripts/simapp/env
+++ b/scripts/simapp/env
@@ -1,4 +1,4 @@
 # Choose from https://hub.docker.com/r/interchainio/simapp/tags
 REPOSITORY="interchainio/simapp"
-VERSION="v0.41.0"
+VERSION="v0.41.3"
 CONTAINER_NAME="simapp"

--- a/scripts/wasmd/env
+++ b/scripts/wasmd/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/cosmwasm/wasmd/tags
 REPOSITORY="cosmwasm/wasmd"
-VERSION="v0.15.0"
+VERSION="v0.15.1"
 
 CONTAINER_NAME="wasmd"


### PR DESCRIPTION
Closes #40 

Allows us to query events by `connection_id`