### PR TITLE
Query all pending packets

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/endpoint.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/endpoint.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/src/lib/endpoint.spec.ts
+++ b/src/lib/endpoint.spec.ts
@@ -54,8 +54,23 @@ test.serial('submit multiple tx, query all packets', async (t) => {
   );
 
   // filter by minimum height
-  const packets3 = await link.endA.querySentPackets(txHeights[1]);
+  const packets3 = await link.endA.querySentPackets({
+    minHeight: txHeights[1],
+  });
   t.is(packets3.length, 2);
-  const packets4 = await link.endA.querySentPackets(txHeights[2] + 1);
+  const packets4 = await link.endA.querySentPackets({
+    minHeight: txHeights[2] + 1,
+  });
   t.is(packets4.length, 0);
+
+  // filter by maximum height
+  const packets5 = await link.endA.querySentPackets({
+    maxHeight: txHeights[1],
+  });
+  t.is(packets5.length, 2);
+  const packets6 = await link.endA.querySentPackets({
+    minHeight: txHeights[1],
+    maxHeight: txHeights[1],
+  });
+  t.is(packets6.length, 1);
 });

--- a/src/lib/endpoint.spec.ts
+++ b/src/lib/endpoint.spec.ts
@@ -3,7 +3,7 @@ import test from 'ava';
 import { Link } from './link';
 import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
 
-test.serial.only('submit multiple tx, query all packets', async (t) => {
+test.serial('submit multiple tx, query all packets', async (t) => {
   // setup a channel
   const [nodeA, nodeB] = await setup();
   const link = await Link.createWithNewConnections(nodeA, nodeB);
@@ -53,9 +53,9 @@ test.serial.only('submit multiple tx, query all packets', async (t) => {
     txHeights
   );
 
-  // // filter by minimum height
-  // const packets3 = await link.endA.querySentPackets(txHeights[1]);
-  // t.is(packets3.length, 2);
-  // const packets4 = await link.endA.querySentPackets(txHeights[2] + 1);
-  // t.is(packets4.length, 0);
+  // filter by minimum height
+  const packets3 = await link.endA.querySentPackets(txHeights[1]);
+  t.is(packets3.length, 2);
+  const packets4 = await link.endA.querySentPackets(txHeights[2] + 1);
+  t.is(packets4.length, 0);
 });

--- a/src/lib/endpoint.spec.ts
+++ b/src/lib/endpoint.spec.ts
@@ -16,7 +16,7 @@ test.serial.only('submit multiple tx, query all packets', async (t) => {
   );
 
   // no packets here
-  const packets1 = await link.endA.getPendingPackets();
+  const packets1 = await link.endA.querySentPackets();
   t.is(packets1.length, 0);
 
   // some basic setup for the transfers
@@ -46,13 +46,16 @@ test.serial.only('submit multiple tx, query all packets', async (t) => {
   await nodeA.waitOneBlock();
 
   // now query for all packets
-  const packets2 = await link.endA.getPendingPackets();
+  const packets2 = await link.endA.querySentPackets();
   t.is(packets2.length, 3);
-  console.log(packets2);
+  t.deepEqual(
+    packets2.map(({ height }) => height),
+    txHeights
+  );
 
   // // filter by minimum height
-  // const packets3 = await link.endA.getPendingPackets(txHeights[1]);
+  // const packets3 = await link.endA.querySentPackets(txHeights[1]);
   // t.is(packets3.length, 2);
-  // const packets4 = await link.endA.getPendingPackets(txHeights[2] + 1);
+  // const packets4 = await link.endA.querySentPackets(txHeights[2] + 1);
   // t.is(packets4.length, 0);
 });

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -39,10 +39,7 @@ export class Endpoint {
   // https://github.com/cosmos/cosmjs/issues/632
 
   /* eslint @typescript-eslint/no-unused-vars: "off" */
-  public async getPendingPackets(
-    _filter?: Filter,
-    _minHeight?: number
-  ): Promise<Packet[]> {
+  public async getPendingPackets(_minHeight?: number): Promise<Packet[]> {
     this.client.query.ibc.channel.connectionChannels(this.connectionID);
 
     // these all work for one (port, channel).
@@ -57,10 +54,7 @@ export class Endpoint {
   }
 
   /* eslint @typescript-eslint/no-unused-vars: "off" */
-  public async getPendingAcks(
-    _filter?: Filter,
-    _minHeight?: number
-  ): Promise<Ack[]> {
+  public async getPendingAcks(_minHeight?: number): Promise<Ack[]> {
     throw new Error('unimplemented!');
   }
 

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -42,7 +42,7 @@ export class Endpoint {
   }
 
   // TODO: return info for pagination, accept arg
-  public async getPendingPackets(
+  public async querySentPackets(
     minHeight?: number
   ): Promise<PacketWithMetadata[]> {
     // TODO: txSearchAll or do we paginate?
@@ -55,7 +55,6 @@ export class Endpoint {
     const search = await this.client.tm.txSearch({ query });
     console.log(search.totalCount);
     const resultsNested = search.txs.map(({ height, result }) => {
-      console.log(`height: ${height}`);
       const logs = parseRawLog(result.log);
       return parsePacketsFromLogs(logs).map((packet) => ({ packet, height }));
     });

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -48,7 +48,7 @@ export class Endpoint {
     // TODO: txSearchAll or do we paginate?
     let query = `send_packet.packet_connection='${this.connectionID}'`;
     if (minHeight) {
-      query = `${query}&tx.minheight=${minHeight}`;
+      query = `${query} AND tx.height>=${minHeight}`;
     }
     console.log(query);
 

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -2,11 +2,10 @@ import { sleep } from '@cosmjs/utils';
 import test from 'ava';
 
 import { MsgTransfer } from '../codec/ibc/applications/transfer/v1/tx';
-import { Order } from '../codec/ibc/core/channel/v1/channel';
 
 import { buildCreateClientArgs, prepareConnectionHandshake } from './ibcclient';
 import { Link } from './link';
-import { randomAddress, setup, simapp, wasmd } from './testutils.spec';
+import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
 import {
   buildClientState,
   buildConsensusState,
@@ -154,15 +153,6 @@ test.serial('perform connection handshake', async (t) => {
   );
   await dest.connOpenConfirm(proofConfirm);
 });
-
-// constants for this transport protocol
-const ics20 = {
-  // we set a new port in genesis for simapp
-  srcPortId: 'custom',
-  destPortId: 'transfer',
-  version: 'ics20-1',
-  ordering: Order.ORDER_UNORDERED,
-};
 
 test.serial('transfer message and send packets', async (t) => {
   // set up ics20 channel

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -127,6 +127,8 @@ export interface MsgResult {
   readonly logs: readonly logs.Log[];
   /** Transaction hash (might be used as transaction ID). Guaranteed to be non-empty upper-case hex */
   readonly transactionHash: string;
+  /** block height where this transaction was committed - only set if we send 'block' mode */
+  readonly height: number;
 }
 
 export type CreateClientResult = MsgResult & {
@@ -518,6 +520,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -535,6 +538,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -576,6 +580,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
       clientId,
     };
   }
@@ -609,6 +614,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -648,6 +654,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
       connectionId,
     };
   }
@@ -705,6 +712,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
       connectionId: myConnectionId,
     };
   }
@@ -751,6 +759,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -781,6 +790,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -826,6 +836,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
       channelId,
     };
   }
@@ -876,6 +887,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
       channelId,
     };
   }
@@ -914,6 +926,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -947,6 +960,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -998,6 +1012,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -1050,6 +1065,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -1082,6 +1098,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 
@@ -1123,6 +1140,7 @@ export class IbcClient {
     return {
       logs: parsedLogs,
       transactionHash: result.transactionHash,
+      height: result.height,
     };
   }
 }

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -3,7 +3,7 @@ import test from 'ava';
 import { State } from '../codec/ibc/core/channel/v1/channel';
 
 import { Link } from './link';
-import { ics20, setup } from './testutils.spec';
+import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
 
 // createWithNewConnections
 
@@ -189,5 +189,56 @@ test.serial(`errors when reusing connections which don’t match`, async (t) => 
 
   await t.throwsAsync(() =>
     Link.createWithExistingConnections(src, dest, connA, connB)
+  );
+});
+
+test.serial.only('submit multiple tx, get unreceived packets', async (t) => {
+  // setup a channel
+  const [nodeA, nodeB] = await setup();
+  const link = await Link.createWithNewConnections(nodeA, nodeB);
+  const channels = await link.createChannel(
+    'A',
+    ics20.srcPortId,
+    ics20.destPortId,
+    ics20.ordering,
+    ics20.version
+  );
+
+  // no packets here
+  const packets1 = await link.endA.querySentPackets();
+  t.is(packets1.length, 0);
+
+  // some basic setup for the transfers
+  const recipient = randomAddress(wasmd.prefix);
+  const destHeight = (await nodeB.latestHeader()).height + 500; // valid for 500 blocks
+  const amounts = [1000, 2222, 3456];
+  // const totalSent = amounts.reduce((a, b) => a + b, 0);
+
+  // let's make 3 transfer tx at different heights
+  const txHeights = [];
+  for (const amount of amounts) {
+    const token = { amount: amount.toString(), denom: simapp.denomFee };
+    const { height } = await nodeA.transferTokens(
+      channels.src.portId,
+      channels.src.channelId,
+      token,
+      recipient,
+      destHeight
+    );
+    // console.log(JSON.stringify(logs[0].events, undefined, 2));
+    txHeights.push(height);
+  }
+  // ensure these are different
+  t.assert(txHeights[1] > txHeights[0], txHeights.toString());
+  t.assert(txHeights[2] > txHeights[1], txHeights.toString());
+  // wait for this to get indexed
+  await nodeA.waitOneBlock();
+
+  // now query for all packets
+  const packets2 = await link.getPendingPackets('A');
+  t.is(packets2.length, 3);
+  t.deepEqual(
+    packets2.map(({ height }) => height),
+    txHeights
   );
 });

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -1,18 +1,9 @@
 import test from 'ava';
 
-import { Order, State } from '../codec/ibc/core/channel/v1/channel';
+import { State } from '../codec/ibc/core/channel/v1/channel';
 
 import { Link } from './link';
-import { setup } from './testutils.spec';
-
-// constants for this transport protocol
-const ics20 = {
-  // we set a new port in genesis for simapp
-  srcPortId: 'custom',
-  destPortId: 'transfer',
-  version: 'ics20-1',
-  ordering: Order.ORDER_UNORDERED,
-};
+import { ics20, setup } from './testutils.spec';
 
 // createWithNewConnections
 

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -191,7 +191,7 @@ test.serial(`errors when reusing connections which don’t match`, async (t) => 
   );
 });
 
-test.serial.only('submit multiple tx, get unreceived packets', async (t) => {
+test.serial('submit multiple tx, get unreceived packets', async (t) => {
   // setup a channel
   const [nodeA, nodeB] = await setup();
   const link = await Link.createWithNewConnections(nodeA, nodeB);
@@ -240,6 +240,10 @@ test.serial.only('submit multiple tx, get unreceived packets', async (t) => {
     packets.map(({ height }) => height),
     txHeights
   );
+  // ensure the sender is set properly
+  for (const packet of packets) {
+    t.is(packet.sender, nodeA.senderAddress);
+  }
 
   // submit 2 of them (out of order)
   const submit = [packets[0].packet, packets[2].packet];

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -226,13 +226,15 @@ export class Link {
    * Writes the latest header from the sender chain to the other endpoint
    *
    * @param sender Which side we get the header/commit from
+   * @returns header height (from sender) that is now known on dest
    *
    * Relayer binary should call this from a heartbeat which checks if needed and updates.
    * Just needs trusting period on both side
    */
-  public async updateClient(sender: Side): Promise<void> {
+  public async updateClient(sender: Side): Promise<number> {
     const { src, dest } = this.getEnds(sender);
-    await dest.client.doUpdateClient(dest.clientID, src.client);
+    const height = await dest.client.doUpdateClient(dest.clientID, src.client);
+    return height;
   }
 
   /* eslint @typescript-eslint/no-unused-vars: "off" */

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -6,6 +6,8 @@ import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { StargateClient } from '@cosmjs/stargate';
 import test from 'ava';
 
+import { Order } from '../codec/ibc/core/channel/v1/channel';
+
 import { IbcClient, IbcClientOptions } from './ibcclient';
 
 export const simapp = {
@@ -67,6 +69,16 @@ export const wasmd = {
     balanceStaking: '10000000', // 10 STAKE
     balanceFee: '1000000000', // 1000 COSM
   },
+};
+
+// constants for this transport protocol
+// we assume src = simapp, dest = wasmd as returned by setup()
+export const ics20 = {
+  // we set a new port in genesis for simapp
+  srcPortId: 'custom',
+  destPortId: 'transfer',
+  version: 'ics20-1',
+  ordering: Order.ORDER_UNORDERED,
 };
 
 interface SigningOpts {


### PR DESCRIPTION
Closes #43

- [x] Query for txs by connection (with optional min/max height)
- [x] Parse Packet data and return
- [x] Add code to check for unreceived packets
- [x] Test unreceived packets check
- [x] Return `sender` along with packet metadata

Next PR:
- [ ] Improve unreceived check to handle multiple channels on connection  