### PR TITLE
Update ts-proto to 1.67 and regenerate codecs

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier": "^2.1.1",
     "standard-version": "^9.0.0",
     "ts-node": "^9.0.0",
-    "ts-proto": "^1.53.0",
+    "ts-proto": "^1.67.0",
     "typedoc": "^0.19.0",
     "typescript": "^4.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/ibcclient.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/src/codec/confio/proofs.ts
+++ b/src/codec/confio/proofs.ts
@@ -345,9 +345,13 @@ export const ExistenceProof = {
     message: ExistenceProof,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    writer.uint32(18).bytes(message.value);
-    if (message.leaf !== undefined && message.leaf !== undefined) {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(18).bytes(message.value);
+    }
+    if (message.leaf !== undefined) {
       LeafOp.encode(message.leaf, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.path) {
@@ -406,6 +410,26 @@ export const ExistenceProof = {
     return message;
   },
 
+  toJSON(message: ExistenceProof): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    message.leaf !== undefined &&
+      (obj.leaf = message.leaf ? LeafOp.toJSON(message.leaf) : undefined);
+    if (message.path) {
+      obj.path = message.path.map((e) => (e ? InnerOp.toJSON(e) : undefined));
+    } else {
+      obj.path = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ExistenceProof>): ExistenceProof {
     const message = { ...baseExistenceProof } as ExistenceProof;
     message.path = [];
@@ -431,26 +455,6 @@ export const ExistenceProof = {
     }
     return message;
   },
-
-  toJSON(message: ExistenceProof): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    message.leaf !== undefined &&
-      (obj.leaf = message.leaf ? LeafOp.toJSON(message.leaf) : undefined);
-    if (message.path) {
-      obj.path = message.path.map((e) => (e ? InnerOp.toJSON(e) : undefined));
-    } else {
-      obj.path = [];
-    }
-    return obj;
-  },
 };
 
 const baseNonExistenceProof: object = {};
@@ -460,11 +464,13 @@ export const NonExistenceProof = {
     message: NonExistenceProof,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    if (message.left !== undefined && message.left !== undefined) {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.left !== undefined) {
       ExistenceProof.encode(message.left, writer.uint32(18).fork()).ldelim();
     }
-    if (message.right !== undefined && message.right !== undefined) {
+    if (message.right !== undefined) {
       ExistenceProof.encode(message.right, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -512,6 +518,23 @@ export const NonExistenceProof = {
     return message;
   },
 
+  toJSON(message: NonExistenceProof): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.left !== undefined &&
+      (obj.left = message.left
+        ? ExistenceProof.toJSON(message.left)
+        : undefined);
+    message.right !== undefined &&
+      (obj.right = message.right
+        ? ExistenceProof.toJSON(message.right)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<NonExistenceProof>): NonExistenceProof {
     const message = { ...baseNonExistenceProof } as NonExistenceProof;
     if (object.key !== undefined && object.key !== null) {
@@ -530,23 +553,6 @@ export const NonExistenceProof = {
       message.right = undefined;
     }
     return message;
-  },
-
-  toJSON(message: NonExistenceProof): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.left !== undefined &&
-      (obj.left = message.left
-        ? ExistenceProof.toJSON(message.left)
-        : undefined);
-    message.right !== undefined &&
-      (obj.right = message.right
-        ? ExistenceProof.toJSON(message.right)
-        : undefined);
-    return obj;
   },
 };
 
@@ -633,6 +639,27 @@ export const CommitmentProof = {
     return message;
   },
 
+  toJSON(message: CommitmentProof): unknown {
+    const obj: any = {};
+    message.exist !== undefined &&
+      (obj.exist = message.exist
+        ? ExistenceProof.toJSON(message.exist)
+        : undefined);
+    message.nonexist !== undefined &&
+      (obj.nonexist = message.nonexist
+        ? NonExistenceProof.toJSON(message.nonexist)
+        : undefined);
+    message.batch !== undefined &&
+      (obj.batch = message.batch
+        ? BatchProof.toJSON(message.batch)
+        : undefined);
+    message.compressed !== undefined &&
+      (obj.compressed = message.compressed
+        ? CompressedBatchProof.toJSON(message.compressed)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<CommitmentProof>): CommitmentProof {
     const message = { ...baseCommitmentProof } as CommitmentProof;
     if (object.exist !== undefined && object.exist !== null) {
@@ -657,27 +684,6 @@ export const CommitmentProof = {
     }
     return message;
   },
-
-  toJSON(message: CommitmentProof): unknown {
-    const obj: any = {};
-    message.exist !== undefined &&
-      (obj.exist = message.exist
-        ? ExistenceProof.toJSON(message.exist)
-        : undefined);
-    message.nonexist !== undefined &&
-      (obj.nonexist = message.nonexist
-        ? NonExistenceProof.toJSON(message.nonexist)
-        : undefined);
-    message.batch !== undefined &&
-      (obj.batch = message.batch
-        ? BatchProof.toJSON(message.batch)
-        : undefined);
-    message.compressed !== undefined &&
-      (obj.compressed = message.compressed
-        ? CompressedBatchProof.toJSON(message.compressed)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseLeafOp: object = {
@@ -692,11 +698,21 @@ export const LeafOp = {
     message: LeafOp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.hash);
-    writer.uint32(16).int32(message.prehashKey);
-    writer.uint32(24).int32(message.prehashValue);
-    writer.uint32(32).int32(message.length);
-    writer.uint32(42).bytes(message.prefix);
+    if (message.hash !== 0) {
+      writer.uint32(8).int32(message.hash);
+    }
+    if (message.prehashKey !== 0) {
+      writer.uint32(16).int32(message.prehashKey);
+    }
+    if (message.prehashValue !== 0) {
+      writer.uint32(24).int32(message.prehashValue);
+    }
+    if (message.length !== 0) {
+      writer.uint32(32).int32(message.length);
+    }
+    if (message.prefix.length !== 0) {
+      writer.uint32(42).bytes(message.prefix);
+    }
     return writer;
   },
 
@@ -758,6 +774,22 @@ export const LeafOp = {
     return message;
   },
 
+  toJSON(message: LeafOp): unknown {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
+    message.prehashKey !== undefined &&
+      (obj.prehashKey = hashOpToJSON(message.prehashKey));
+    message.prehashValue !== undefined &&
+      (obj.prehashValue = hashOpToJSON(message.prehashValue));
+    message.length !== undefined &&
+      (obj.length = lengthOpToJSON(message.length));
+    message.prefix !== undefined &&
+      (obj.prefix = base64FromBytes(
+        message.prefix !== undefined ? message.prefix : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<LeafOp>): LeafOp {
     const message = { ...baseLeafOp } as LeafOp;
     if (object.hash !== undefined && object.hash !== null) {
@@ -787,22 +819,6 @@ export const LeafOp = {
     }
     return message;
   },
-
-  toJSON(message: LeafOp): unknown {
-    const obj: any = {};
-    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
-    message.prehashKey !== undefined &&
-      (obj.prehashKey = hashOpToJSON(message.prehashKey));
-    message.prehashValue !== undefined &&
-      (obj.prehashValue = hashOpToJSON(message.prehashValue));
-    message.length !== undefined &&
-      (obj.length = lengthOpToJSON(message.length));
-    message.prefix !== undefined &&
-      (obj.prefix = base64FromBytes(
-        message.prefix !== undefined ? message.prefix : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseInnerOp: object = { hash: 0 };
@@ -812,9 +828,15 @@ export const InnerOp = {
     message: InnerOp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.hash);
-    writer.uint32(18).bytes(message.prefix);
-    writer.uint32(26).bytes(message.suffix);
+    if (message.hash !== 0) {
+      writer.uint32(8).int32(message.hash);
+    }
+    if (message.prefix.length !== 0) {
+      writer.uint32(18).bytes(message.prefix);
+    }
+    if (message.suffix.length !== 0) {
+      writer.uint32(26).bytes(message.suffix);
+    }
     return writer;
   },
 
@@ -858,6 +880,20 @@ export const InnerOp = {
     return message;
   },
 
+  toJSON(message: InnerOp): unknown {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
+    message.prefix !== undefined &&
+      (obj.prefix = base64FromBytes(
+        message.prefix !== undefined ? message.prefix : new Uint8Array()
+      ));
+    message.suffix !== undefined &&
+      (obj.suffix = base64FromBytes(
+        message.suffix !== undefined ? message.suffix : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<InnerOp>): InnerOp {
     const message = { ...baseInnerOp } as InnerOp;
     if (object.hash !== undefined && object.hash !== null) {
@@ -877,20 +913,6 @@ export const InnerOp = {
     }
     return message;
   },
-
-  toJSON(message: InnerOp): unknown {
-    const obj: any = {};
-    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
-    message.prefix !== undefined &&
-      (obj.prefix = base64FromBytes(
-        message.prefix !== undefined ? message.prefix : new Uint8Array()
-      ));
-    message.suffix !== undefined &&
-      (obj.suffix = base64FromBytes(
-        message.suffix !== undefined ? message.suffix : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseProofSpec: object = { maxDepth: 0, minDepth: 0 };
@@ -900,14 +922,18 @@ export const ProofSpec = {
     message: ProofSpec,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.leafSpec !== undefined && message.leafSpec !== undefined) {
+    if (message.leafSpec !== undefined) {
       LeafOp.encode(message.leafSpec, writer.uint32(10).fork()).ldelim();
     }
-    if (message.innerSpec !== undefined && message.innerSpec !== undefined) {
+    if (message.innerSpec !== undefined) {
       InnerSpec.encode(message.innerSpec, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).int32(message.maxDepth);
-    writer.uint32(32).int32(message.minDepth);
+    if (message.maxDepth !== 0) {
+      writer.uint32(24).int32(message.maxDepth);
+    }
+    if (message.minDepth !== 0) {
+      writer.uint32(32).int32(message.minDepth);
+    }
     return writer;
   },
 
@@ -963,6 +989,21 @@ export const ProofSpec = {
     return message;
   },
 
+  toJSON(message: ProofSpec): unknown {
+    const obj: any = {};
+    message.leafSpec !== undefined &&
+      (obj.leafSpec = message.leafSpec
+        ? LeafOp.toJSON(message.leafSpec)
+        : undefined);
+    message.innerSpec !== undefined &&
+      (obj.innerSpec = message.innerSpec
+        ? InnerSpec.toJSON(message.innerSpec)
+        : undefined);
+    message.maxDepth !== undefined && (obj.maxDepth = message.maxDepth);
+    message.minDepth !== undefined && (obj.minDepth = message.minDepth);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ProofSpec>): ProofSpec {
     const message = { ...baseProofSpec } as ProofSpec;
     if (object.leafSpec !== undefined && object.leafSpec !== null) {
@@ -987,21 +1028,6 @@ export const ProofSpec = {
     }
     return message;
   },
-
-  toJSON(message: ProofSpec): unknown {
-    const obj: any = {};
-    message.leafSpec !== undefined &&
-      (obj.leafSpec = message.leafSpec
-        ? LeafOp.toJSON(message.leafSpec)
-        : undefined);
-    message.innerSpec !== undefined &&
-      (obj.innerSpec = message.innerSpec
-        ? InnerSpec.toJSON(message.innerSpec)
-        : undefined);
-    message.maxDepth !== undefined && (obj.maxDepth = message.maxDepth);
-    message.minDepth !== undefined && (obj.minDepth = message.minDepth);
-    return obj;
-  },
 };
 
 const baseInnerSpec: object = {
@@ -1022,11 +1048,21 @@ export const InnerSpec = {
       writer.int32(v);
     }
     writer.ldelim();
-    writer.uint32(16).int32(message.childSize);
-    writer.uint32(24).int32(message.minPrefixLength);
-    writer.uint32(32).int32(message.maxPrefixLength);
-    writer.uint32(42).bytes(message.emptyChild);
-    writer.uint32(48).int32(message.hash);
+    if (message.childSize !== 0) {
+      writer.uint32(16).int32(message.childSize);
+    }
+    if (message.minPrefixLength !== 0) {
+      writer.uint32(24).int32(message.minPrefixLength);
+    }
+    if (message.maxPrefixLength !== 0) {
+      writer.uint32(32).int32(message.maxPrefixLength);
+    }
+    if (message.emptyChild.length !== 0) {
+      writer.uint32(42).bytes(message.emptyChild);
+    }
+    if (message.hash !== 0) {
+      writer.uint32(48).int32(message.hash);
+    }
     return writer;
   },
 
@@ -1111,6 +1147,26 @@ export const InnerSpec = {
     return message;
   },
 
+  toJSON(message: InnerSpec): unknown {
+    const obj: any = {};
+    if (message.childOrder) {
+      obj.childOrder = message.childOrder.map((e) => e);
+    } else {
+      obj.childOrder = [];
+    }
+    message.childSize !== undefined && (obj.childSize = message.childSize);
+    message.minPrefixLength !== undefined &&
+      (obj.minPrefixLength = message.minPrefixLength);
+    message.maxPrefixLength !== undefined &&
+      (obj.maxPrefixLength = message.maxPrefixLength);
+    message.emptyChild !== undefined &&
+      (obj.emptyChild = base64FromBytes(
+        message.emptyChild !== undefined ? message.emptyChild : new Uint8Array()
+      ));
+    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<InnerSpec>): InnerSpec {
     const message = { ...baseInnerSpec } as InnerSpec;
     message.childOrder = [];
@@ -1151,26 +1207,6 @@ export const InnerSpec = {
       message.hash = 0;
     }
     return message;
-  },
-
-  toJSON(message: InnerSpec): unknown {
-    const obj: any = {};
-    if (message.childOrder) {
-      obj.childOrder = message.childOrder.map((e) => e);
-    } else {
-      obj.childOrder = [];
-    }
-    message.childSize !== undefined && (obj.childSize = message.childSize);
-    message.minPrefixLength !== undefined &&
-      (obj.minPrefixLength = message.minPrefixLength);
-    message.maxPrefixLength !== undefined &&
-      (obj.maxPrefixLength = message.maxPrefixLength);
-    message.emptyChild !== undefined &&
-      (obj.emptyChild = base64FromBytes(
-        message.emptyChild !== undefined ? message.emptyChild : new Uint8Array()
-      ));
-    message.hash !== undefined && (obj.hash = hashOpToJSON(message.hash));
-    return obj;
   },
 };
 
@@ -1217,17 +1253,6 @@ export const BatchProof = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<BatchProof>): BatchProof {
-    const message = { ...baseBatchProof } as BatchProof;
-    message.entries = [];
-    if (object.entries !== undefined && object.entries !== null) {
-      for (const e of object.entries) {
-        message.entries.push(BatchEntry.fromPartial(e));
-      }
-    }
-    return message;
-  },
-
   toJSON(message: BatchProof): unknown {
     const obj: any = {};
     if (message.entries) {
@@ -1238,6 +1263,17 @@ export const BatchProof = {
       obj.entries = [];
     }
     return obj;
+  },
+
+  fromPartial(object: DeepPartial<BatchProof>): BatchProof {
+    const message = { ...baseBatchProof } as BatchProof;
+    message.entries = [];
+    if (object.entries !== undefined && object.entries !== null) {
+      for (const e of object.entries) {
+        message.entries.push(BatchEntry.fromPartial(e));
+      }
+    }
+    return message;
   },
 };
 
@@ -1296,6 +1332,19 @@ export const BatchEntry = {
     return message;
   },
 
+  toJSON(message: BatchEntry): unknown {
+    const obj: any = {};
+    message.exist !== undefined &&
+      (obj.exist = message.exist
+        ? ExistenceProof.toJSON(message.exist)
+        : undefined);
+    message.nonexist !== undefined &&
+      (obj.nonexist = message.nonexist
+        ? NonExistenceProof.toJSON(message.nonexist)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BatchEntry>): BatchEntry {
     const message = { ...baseBatchEntry } as BatchEntry;
     if (object.exist !== undefined && object.exist !== null) {
@@ -1309,19 +1358,6 @@ export const BatchEntry = {
       message.nonexist = undefined;
     }
     return message;
-  },
-
-  toJSON(message: BatchEntry): unknown {
-    const obj: any = {};
-    message.exist !== undefined &&
-      (obj.exist = message.exist
-        ? ExistenceProof.toJSON(message.exist)
-        : undefined);
-    message.nonexist !== undefined &&
-      (obj.nonexist = message.nonexist
-        ? NonExistenceProof.toJSON(message.nonexist)
-        : undefined);
-    return obj;
   },
 };
 
@@ -1386,23 +1422,6 @@ export const CompressedBatchProof = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<CompressedBatchProof>): CompressedBatchProof {
-    const message = { ...baseCompressedBatchProof } as CompressedBatchProof;
-    message.entries = [];
-    message.lookupInners = [];
-    if (object.entries !== undefined && object.entries !== null) {
-      for (const e of object.entries) {
-        message.entries.push(CompressedBatchEntry.fromPartial(e));
-      }
-    }
-    if (object.lookupInners !== undefined && object.lookupInners !== null) {
-      for (const e of object.lookupInners) {
-        message.lookupInners.push(InnerOp.fromPartial(e));
-      }
-    }
-    return message;
-  },
-
   toJSON(message: CompressedBatchProof): unknown {
     const obj: any = {};
     if (message.entries) {
@@ -1420,6 +1439,23 @@ export const CompressedBatchProof = {
       obj.lookupInners = [];
     }
     return obj;
+  },
+
+  fromPartial(object: DeepPartial<CompressedBatchProof>): CompressedBatchProof {
+    const message = { ...baseCompressedBatchProof } as CompressedBatchProof;
+    message.entries = [];
+    message.lookupInners = [];
+    if (object.entries !== undefined && object.entries !== null) {
+      for (const e of object.entries) {
+        message.entries.push(CompressedBatchEntry.fromPartial(e));
+      }
+    }
+    if (object.lookupInners !== undefined && object.lookupInners !== null) {
+      for (const e of object.lookupInners) {
+        message.lookupInners.push(InnerOp.fromPartial(e));
+      }
+    }
+    return message;
   },
 };
 
@@ -1490,6 +1526,19 @@ export const CompressedBatchEntry = {
     return message;
   },
 
+  toJSON(message: CompressedBatchEntry): unknown {
+    const obj: any = {};
+    message.exist !== undefined &&
+      (obj.exist = message.exist
+        ? CompressedExistenceProof.toJSON(message.exist)
+        : undefined);
+    message.nonexist !== undefined &&
+      (obj.nonexist = message.nonexist
+        ? CompressedNonExistenceProof.toJSON(message.nonexist)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<CompressedBatchEntry>): CompressedBatchEntry {
     const message = { ...baseCompressedBatchEntry } as CompressedBatchEntry;
     if (object.exist !== undefined && object.exist !== null) {
@@ -1506,19 +1555,6 @@ export const CompressedBatchEntry = {
     }
     return message;
   },
-
-  toJSON(message: CompressedBatchEntry): unknown {
-    const obj: any = {};
-    message.exist !== undefined &&
-      (obj.exist = message.exist
-        ? CompressedExistenceProof.toJSON(message.exist)
-        : undefined);
-    message.nonexist !== undefined &&
-      (obj.nonexist = message.nonexist
-        ? CompressedNonExistenceProof.toJSON(message.nonexist)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseCompressedExistenceProof: object = { path: 0 };
@@ -1528,9 +1564,13 @@ export const CompressedExistenceProof = {
     message: CompressedExistenceProof,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    writer.uint32(18).bytes(message.value);
-    if (message.leaf !== undefined && message.leaf !== undefined) {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(18).bytes(message.value);
+    }
+    if (message.leaf !== undefined) {
       LeafOp.encode(message.leaf, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(34).fork();
@@ -1605,6 +1645,26 @@ export const CompressedExistenceProof = {
     return message;
   },
 
+  toJSON(message: CompressedExistenceProof): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    message.leaf !== undefined &&
+      (obj.leaf = message.leaf ? LeafOp.toJSON(message.leaf) : undefined);
+    if (message.path) {
+      obj.path = message.path.map((e) => e);
+    } else {
+      obj.path = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<CompressedExistenceProof>
   ): CompressedExistenceProof {
@@ -1634,26 +1694,6 @@ export const CompressedExistenceProof = {
     }
     return message;
   },
-
-  toJSON(message: CompressedExistenceProof): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    message.leaf !== undefined &&
-      (obj.leaf = message.leaf ? LeafOp.toJSON(message.leaf) : undefined);
-    if (message.path) {
-      obj.path = message.path.map((e) => e);
-    } else {
-      obj.path = [];
-    }
-    return obj;
-  },
 };
 
 const baseCompressedNonExistenceProof: object = {};
@@ -1663,14 +1703,16 @@ export const CompressedNonExistenceProof = {
     message: CompressedNonExistenceProof,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    if (message.left !== undefined && message.left !== undefined) {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.left !== undefined) {
       CompressedExistenceProof.encode(
         message.left,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.right !== undefined && message.right !== undefined) {
+    if (message.right !== undefined) {
       CompressedExistenceProof.encode(
         message.right,
         writer.uint32(26).fork()
@@ -1734,6 +1776,23 @@ export const CompressedNonExistenceProof = {
     return message;
   },
 
+  toJSON(message: CompressedNonExistenceProof): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.left !== undefined &&
+      (obj.left = message.left
+        ? CompressedExistenceProof.toJSON(message.left)
+        : undefined);
+    message.right !== undefined &&
+      (obj.right = message.right
+        ? CompressedExistenceProof.toJSON(message.right)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<CompressedNonExistenceProof>
   ): CompressedNonExistenceProof {
@@ -1757,23 +1816,6 @@ export const CompressedNonExistenceProof = {
     }
     return message;
   },
-
-  toJSON(message: CompressedNonExistenceProof): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.left !== undefined &&
-      (obj.left = message.left
-        ? CompressedExistenceProof.toJSON(message.left)
-        : undefined);
-    message.right !== undefined &&
-      (obj.right = message.right
-        ? CompressedExistenceProof.toJSON(message.right)
-        : undefined);
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -1783,7 +1825,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/cosmos/base/query/v1beta1/pagination.ts
+++ b/src/codec/cosmos/base/query/v1beta1/pagination.ts
@@ -73,10 +73,18 @@ export const PageRequest = {
     message: PageRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    writer.uint32(16).uint64(message.offset);
-    writer.uint32(24).uint64(message.limit);
-    writer.uint32(32).bool(message.countTotal);
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (!message.offset.isZero()) {
+      writer.uint32(16).uint64(message.offset);
+    }
+    if (!message.limit.isZero()) {
+      writer.uint32(24).uint64(message.limit);
+    }
+    if (message.countTotal === true) {
+      writer.uint32(32).bool(message.countTotal);
+    }
     return writer;
   },
 
@@ -130,6 +138,20 @@ export const PageRequest = {
     return message;
   },
 
+  toJSON(message: PageRequest): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.offset !== undefined &&
+      (obj.offset = (message.offset || Long.UZERO).toString());
+    message.limit !== undefined &&
+      (obj.limit = (message.limit || Long.UZERO).toString());
+    message.countTotal !== undefined && (obj.countTotal = message.countTotal);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PageRequest>): PageRequest {
     const message = { ...basePageRequest } as PageRequest;
     if (object.key !== undefined && object.key !== null) {
@@ -154,20 +176,6 @@ export const PageRequest = {
     }
     return message;
   },
-
-  toJSON(message: PageRequest): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.offset !== undefined &&
-      (obj.offset = (message.offset || Long.UZERO).toString());
-    message.limit !== undefined &&
-      (obj.limit = (message.limit || Long.UZERO).toString());
-    message.countTotal !== undefined && (obj.countTotal = message.countTotal);
-    return obj;
-  },
 };
 
 const basePageResponse: object = { total: Long.UZERO };
@@ -177,8 +185,12 @@ export const PageResponse = {
     message: PageResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.nextKey);
-    writer.uint32(16).uint64(message.total);
+    if (message.nextKey.length !== 0) {
+      writer.uint32(10).bytes(message.nextKey);
+    }
+    if (!message.total.isZero()) {
+      writer.uint32(16).uint64(message.total);
+    }
     return writer;
   },
 
@@ -216,6 +228,17 @@ export const PageResponse = {
     return message;
   },
 
+  toJSON(message: PageResponse): unknown {
+    const obj: any = {};
+    message.nextKey !== undefined &&
+      (obj.nextKey = base64FromBytes(
+        message.nextKey !== undefined ? message.nextKey : new Uint8Array()
+      ));
+    message.total !== undefined &&
+      (obj.total = (message.total || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PageResponse>): PageResponse {
     const message = { ...basePageResponse } as PageResponse;
     if (object.nextKey !== undefined && object.nextKey !== null) {
@@ -230,17 +253,6 @@ export const PageResponse = {
     }
     return message;
   },
-
-  toJSON(message: PageResponse): unknown {
-    const obj: any = {};
-    message.nextKey !== undefined &&
-      (obj.nextKey = base64FromBytes(
-        message.nextKey !== undefined ? message.nextKey : new Uint8Array()
-      ));
-    message.total !== undefined &&
-      (obj.total = (message.total || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -250,7 +262,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/cosmos/base/v1beta1/coin.ts
+++ b/src/codec/cosmos/base/v1beta1/coin.ts
@@ -40,8 +40,12 @@ const baseCoin: object = { denom: '', amount: '' };
 
 export const Coin = {
   encode(message: Coin, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).string(message.denom);
-    writer.uint32(18).string(message.amount);
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
     return writer;
   },
 
@@ -81,6 +85,13 @@ export const Coin = {
     return message;
   },
 
+  toJSON(message: Coin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Coin>): Coin {
     const message = { ...baseCoin } as Coin;
     if (object.denom !== undefined && object.denom !== null) {
@@ -95,13 +106,6 @@ export const Coin = {
     }
     return message;
   },
-
-  toJSON(message: Coin): unknown {
-    const obj: any = {};
-    message.denom !== undefined && (obj.denom = message.denom);
-    message.amount !== undefined && (obj.amount = message.amount);
-    return obj;
-  },
 };
 
 const baseDecCoin: object = { denom: '', amount: '' };
@@ -111,8 +115,12 @@ export const DecCoin = {
     message: DecCoin,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.denom);
-    writer.uint32(18).string(message.amount);
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
     return writer;
   },
 
@@ -152,6 +160,13 @@ export const DecCoin = {
     return message;
   },
 
+  toJSON(message: DecCoin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<DecCoin>): DecCoin {
     const message = { ...baseDecCoin } as DecCoin;
     if (object.denom !== undefined && object.denom !== null) {
@@ -166,13 +181,6 @@ export const DecCoin = {
     }
     return message;
   },
-
-  toJSON(message: DecCoin): unknown {
-    const obj: any = {};
-    message.denom !== undefined && (obj.denom = message.denom);
-    message.amount !== undefined && (obj.amount = message.amount);
-    return obj;
-  },
 };
 
 const baseIntProto: object = { int: '' };
@@ -182,7 +190,9 @@ export const IntProto = {
     message: IntProto,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.int);
+    if (message.int !== '') {
+      writer.uint32(10).string(message.int);
+    }
     return writer;
   },
 
@@ -214,6 +224,12 @@ export const IntProto = {
     return message;
   },
 
+  toJSON(message: IntProto): unknown {
+    const obj: any = {};
+    message.int !== undefined && (obj.int = message.int);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<IntProto>): IntProto {
     const message = { ...baseIntProto } as IntProto;
     if (object.int !== undefined && object.int !== null) {
@@ -222,12 +238,6 @@ export const IntProto = {
       message.int = '';
     }
     return message;
-  },
-
-  toJSON(message: IntProto): unknown {
-    const obj: any = {};
-    message.int !== undefined && (obj.int = message.int);
-    return obj;
   },
 };
 
@@ -238,7 +248,9 @@ export const DecProto = {
     message: DecProto,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.dec);
+    if (message.dec !== '') {
+      writer.uint32(10).string(message.dec);
+    }
     return writer;
   },
 
@@ -270,6 +282,12 @@ export const DecProto = {
     return message;
   },
 
+  toJSON(message: DecProto): unknown {
+    const obj: any = {};
+    message.dec !== undefined && (obj.dec = message.dec);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<DecProto>): DecProto {
     const message = { ...baseDecProto } as DecProto;
     if (object.dec !== undefined && object.dec !== null) {
@@ -278,12 +296,6 @@ export const DecProto = {
       message.dec = '';
     }
     return message;
-  },
-
-  toJSON(message: DecProto): unknown {
-    const obj: any = {};
-    message.dec !== undefined && (obj.dec = message.dec);
-    return obj;
   },
 };
 

--- a/src/codec/google/protobuf/any.ts
+++ b/src/codec/google/protobuf/any.ts
@@ -124,8 +124,12 @@ const baseAny: object = { typeUrl: '' };
 
 export const Any = {
   encode(message: Any, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).string(message.typeUrl);
-    writer.uint32(18).bytes(message.value);
+    if (message.typeUrl !== '') {
+      writer.uint32(10).string(message.typeUrl);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(18).bytes(message.value);
+    }
     return writer;
   },
 
@@ -163,6 +167,16 @@ export const Any = {
     return message;
   },
 
+  toJSON(message: Any): unknown {
+    const obj: any = {};
+    message.typeUrl !== undefined && (obj.typeUrl = message.typeUrl);
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Any>): Any {
     const message = { ...baseAny } as Any;
     if (object.typeUrl !== undefined && object.typeUrl !== null) {
@@ -177,16 +191,6 @@ export const Any = {
     }
     return message;
   },
-
-  toJSON(message: Any): unknown {
-    const obj: any = {};
-    message.typeUrl !== undefined && (obj.typeUrl = message.typeUrl);
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -196,7 +200,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/google/protobuf/duration.ts
+++ b/src/codec/google/protobuf/duration.ts
@@ -89,8 +89,12 @@ export const Duration = {
     message: Duration,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.seconds);
-    writer.uint32(16).int32(message.nanos);
+    if (!message.seconds.isZero()) {
+      writer.uint32(8).int64(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      writer.uint32(16).int32(message.nanos);
+    }
     return writer;
   },
 
@@ -130,6 +134,14 @@ export const Duration = {
     return message;
   },
 
+  toJSON(message: Duration): unknown {
+    const obj: any = {};
+    message.seconds !== undefined &&
+      (obj.seconds = (message.seconds || Long.ZERO).toString());
+    message.nanos !== undefined && (obj.nanos = message.nanos);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Duration>): Duration {
     const message = { ...baseDuration } as Duration;
     if (object.seconds !== undefined && object.seconds !== null) {
@@ -143,14 +155,6 @@ export const Duration = {
       message.nanos = 0;
     }
     return message;
-  },
-
-  toJSON(message: Duration): unknown {
-    const obj: any = {};
-    message.seconds !== undefined &&
-      (obj.seconds = (message.seconds || Long.ZERO).toString());
-    message.nanos !== undefined && (obj.nanos = message.nanos);
-    return obj;
   },
 };
 

--- a/src/codec/google/protobuf/timestamp.ts
+++ b/src/codec/google/protobuf/timestamp.ts
@@ -120,8 +120,12 @@ export const Timestamp = {
     message: Timestamp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.seconds);
-    writer.uint32(16).int32(message.nanos);
+    if (!message.seconds.isZero()) {
+      writer.uint32(8).int64(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      writer.uint32(16).int32(message.nanos);
+    }
     return writer;
   },
 
@@ -161,6 +165,14 @@ export const Timestamp = {
     return message;
   },
 
+  toJSON(message: Timestamp): unknown {
+    const obj: any = {};
+    message.seconds !== undefined &&
+      (obj.seconds = (message.seconds || Long.ZERO).toString());
+    message.nanos !== undefined && (obj.nanos = message.nanos);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Timestamp>): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
     if (object.seconds !== undefined && object.seconds !== null) {
@@ -174,14 +186,6 @@ export const Timestamp = {
       message.nanos = 0;
     }
     return message;
-  },
-
-  toJSON(message: Timestamp): unknown {
-    const obj: any = {};
-    message.seconds !== undefined &&
-      (obj.seconds = (message.seconds || Long.ZERO).toString());
-    message.nanos !== undefined && (obj.nanos = message.nanos);
-    return obj;
   },
 };
 

--- a/src/codec/ibc/applications/transfer/v1/genesis.ts
+++ b/src/codec/ibc/applications/transfer/v1/genesis.ts
@@ -22,11 +22,13 @@ export const GenesisState = {
     message: GenesisState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
     for (const v of message.denomTraces) {
       DenomTrace.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.params !== undefined && message.params !== undefined) {
+    if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -78,6 +80,21 @@ export const GenesisState = {
     return message;
   },
 
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    if (message.denomTraces) {
+      obj.denomTraces = message.denomTraces.map((e) =>
+        e ? DenomTrace.toJSON(e) : undefined
+      );
+    } else {
+      obj.denomTraces = [];
+    }
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<GenesisState>): GenesisState {
     const message = { ...baseGenesisState } as GenesisState;
     message.denomTraces = [];
@@ -97,21 +114,6 @@ export const GenesisState = {
       message.params = undefined;
     }
     return message;
-  },
-
-  toJSON(message: GenesisState): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    if (message.denomTraces) {
-      obj.denomTraces = message.denomTraces.map((e) =>
-        e ? DenomTrace.toJSON(e) : undefined
-      );
-    } else {
-      obj.denomTraces = [];
-    }
-    message.params !== undefined &&
-      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
-    return obj;
   },
 };
 

--- a/src/codec/ibc/applications/transfer/v1/query.ts
+++ b/src/codec/ibc/applications/transfer/v1/query.ts
@@ -66,7 +66,9 @@ export const QueryDenomTraceRequest = {
     message: QueryDenomTraceRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.hash);
+    if (message.hash !== '') {
+      writer.uint32(10).string(message.hash);
+    }
     return writer;
   },
 
@@ -101,6 +103,12 @@ export const QueryDenomTraceRequest = {
     return message;
   },
 
+  toJSON(message: QueryDenomTraceRequest): unknown {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = message.hash);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryDenomTraceRequest>
   ): QueryDenomTraceRequest {
@@ -112,12 +120,6 @@ export const QueryDenomTraceRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryDenomTraceRequest): unknown {
-    const obj: any = {};
-    message.hash !== undefined && (obj.hash = message.hash);
-    return obj;
-  },
 };
 
 const baseQueryDenomTraceResponse: object = {};
@@ -127,7 +129,7 @@ export const QueryDenomTraceResponse = {
     message: QueryDenomTraceResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.denomTrace !== undefined && message.denomTrace !== undefined) {
+    if (message.denomTrace !== undefined) {
       DenomTrace.encode(message.denomTrace, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -168,6 +170,15 @@ export const QueryDenomTraceResponse = {
     return message;
   },
 
+  toJSON(message: QueryDenomTraceResponse): unknown {
+    const obj: any = {};
+    message.denomTrace !== undefined &&
+      (obj.denomTrace = message.denomTrace
+        ? DenomTrace.toJSON(message.denomTrace)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryDenomTraceResponse>
   ): QueryDenomTraceResponse {
@@ -181,15 +192,6 @@ export const QueryDenomTraceResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryDenomTraceResponse): unknown {
-    const obj: any = {};
-    message.denomTrace !== undefined &&
-      (obj.denomTrace = message.denomTrace
-        ? DenomTrace.toJSON(message.denomTrace)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryDenomTracesRequest: object = {};
@@ -199,7 +201,7 @@ export const QueryDenomTracesRequest = {
     message: QueryDenomTracesRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -240,6 +242,15 @@ export const QueryDenomTracesRequest = {
     return message;
   },
 
+  toJSON(message: QueryDenomTracesRequest): unknown {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryDenomTracesRequest>
   ): QueryDenomTracesRequest {
@@ -253,15 +264,6 @@ export const QueryDenomTracesRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryDenomTracesRequest): unknown {
-    const obj: any = {};
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryDenomTracesResponse: object = {};
@@ -274,7 +276,7 @@ export const QueryDenomTracesResponse = {
     for (const v of message.denomTraces) {
       DenomTrace.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
@@ -328,6 +330,22 @@ export const QueryDenomTracesResponse = {
     return message;
   },
 
+  toJSON(message: QueryDenomTracesResponse): unknown {
+    const obj: any = {};
+    if (message.denomTraces) {
+      obj.denomTraces = message.denomTraces.map((e) =>
+        e ? DenomTrace.toJSON(e) : undefined
+      );
+    } else {
+      obj.denomTraces = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryDenomTracesResponse>
   ): QueryDenomTracesResponse {
@@ -346,22 +364,6 @@ export const QueryDenomTracesResponse = {
       message.pagination = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryDenomTracesResponse): unknown {
-    const obj: any = {};
-    if (message.denomTraces) {
-      obj.denomTraces = message.denomTraces.map((e) =>
-        e ? DenomTrace.toJSON(e) : undefined
-      );
-    } else {
-      obj.denomTraces = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    return obj;
   },
 };
 
@@ -395,14 +397,14 @@ export const QueryParamsRequest = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<QueryParamsRequest>): QueryParamsRequest {
-    const message = { ...baseQueryParamsRequest } as QueryParamsRequest;
-    return message;
-  },
-
   toJSON(_: QueryParamsRequest): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<QueryParamsRequest>): QueryParamsRequest {
+    const message = { ...baseQueryParamsRequest } as QueryParamsRequest;
+    return message;
   },
 };
 
@@ -413,7 +415,7 @@ export const QueryParamsResponse = {
     message: QueryParamsResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.params !== undefined && message.params !== undefined) {
+    if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -447,6 +449,13 @@ export const QueryParamsResponse = {
     return message;
   },
 
+  toJSON(message: QueryParamsResponse): unknown {
+    const obj: any = {};
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<QueryParamsResponse>): QueryParamsResponse {
     const message = { ...baseQueryParamsResponse } as QueryParamsResponse;
     if (object.params !== undefined && object.params !== null) {
@@ -455,13 +464,6 @@ export const QueryParamsResponse = {
       message.params = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryParamsResponse): unknown {
-    const obj: any = {};
-    message.params !== undefined &&
-      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
-    return obj;
   },
 };
 

--- a/src/codec/ibc/applications/transfer/v1/transfer.ts
+++ b/src/codec/ibc/applications/transfer/v1/transfer.ts
@@ -65,10 +65,18 @@ export const FungibleTokenPacketData = {
     message: FungibleTokenPacketData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.denom);
-    writer.uint32(16).uint64(message.amount);
-    writer.uint32(26).string(message.sender);
-    writer.uint32(34).string(message.receiver);
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (!message.amount.isZero()) {
+      writer.uint32(16).uint64(message.amount);
+    }
+    if (message.sender !== '') {
+      writer.uint32(26).string(message.sender);
+    }
+    if (message.receiver !== '') {
+      writer.uint32(34).string(message.receiver);
+    }
     return writer;
   },
 
@@ -131,6 +139,16 @@ export const FungibleTokenPacketData = {
     return message;
   },
 
+  toJSON(message: FungibleTokenPacketData): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined &&
+      (obj.amount = (message.amount || Long.UZERO).toString());
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.receiver !== undefined && (obj.receiver = message.receiver);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<FungibleTokenPacketData>
   ): FungibleTokenPacketData {
@@ -159,16 +177,6 @@ export const FungibleTokenPacketData = {
     }
     return message;
   },
-
-  toJSON(message: FungibleTokenPacketData): unknown {
-    const obj: any = {};
-    message.denom !== undefined && (obj.denom = message.denom);
-    message.amount !== undefined &&
-      (obj.amount = (message.amount || Long.UZERO).toString());
-    message.sender !== undefined && (obj.sender = message.sender);
-    message.receiver !== undefined && (obj.receiver = message.receiver);
-    return obj;
-  },
 };
 
 const baseDenomTrace: object = { path: '', baseDenom: '' };
@@ -178,8 +186,12 @@ export const DenomTrace = {
     message: DenomTrace,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.path);
-    writer.uint32(18).string(message.baseDenom);
+    if (message.path !== '') {
+      writer.uint32(10).string(message.path);
+    }
+    if (message.baseDenom !== '') {
+      writer.uint32(18).string(message.baseDenom);
+    }
     return writer;
   },
 
@@ -219,6 +231,13 @@ export const DenomTrace = {
     return message;
   },
 
+  toJSON(message: DenomTrace): unknown {
+    const obj: any = {};
+    message.path !== undefined && (obj.path = message.path);
+    message.baseDenom !== undefined && (obj.baseDenom = message.baseDenom);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<DenomTrace>): DenomTrace {
     const message = { ...baseDenomTrace } as DenomTrace;
     if (object.path !== undefined && object.path !== null) {
@@ -233,13 +252,6 @@ export const DenomTrace = {
     }
     return message;
   },
-
-  toJSON(message: DenomTrace): unknown {
-    const obj: any = {};
-    message.path !== undefined && (obj.path = message.path);
-    message.baseDenom !== undefined && (obj.baseDenom = message.baseDenom);
-    return obj;
-  },
 };
 
 const baseParams: object = { sendEnabled: false, receiveEnabled: false };
@@ -249,8 +261,12 @@ export const Params = {
     message: Params,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).bool(message.sendEnabled);
-    writer.uint32(16).bool(message.receiveEnabled);
+    if (message.sendEnabled === true) {
+      writer.uint32(8).bool(message.sendEnabled);
+    }
+    if (message.receiveEnabled === true) {
+      writer.uint32(16).bool(message.receiveEnabled);
+    }
     return writer;
   },
 
@@ -290,6 +306,15 @@ export const Params = {
     return message;
   },
 
+  toJSON(message: Params): unknown {
+    const obj: any = {};
+    message.sendEnabled !== undefined &&
+      (obj.sendEnabled = message.sendEnabled);
+    message.receiveEnabled !== undefined &&
+      (obj.receiveEnabled = message.receiveEnabled);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Params>): Params {
     const message = { ...baseParams } as Params;
     if (object.sendEnabled !== undefined && object.sendEnabled !== null) {
@@ -303,15 +328,6 @@ export const Params = {
       message.receiveEnabled = false;
     }
     return message;
-  },
-
-  toJSON(message: Params): unknown {
-    const obj: any = {};
-    message.sendEnabled !== undefined &&
-      (obj.sendEnabled = message.sendEnabled);
-    message.receiveEnabled !== undefined &&
-      (obj.receiveEnabled = message.receiveEnabled);
-    return obj;
   },
 };
 

--- a/src/codec/ibc/applications/transfer/v1/tx.ts
+++ b/src/codec/ibc/applications/transfer/v1/tx.ts
@@ -50,20 +50,27 @@ export const MsgTransfer = {
     message: MsgTransfer,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.sourcePort);
-    writer.uint32(18).string(message.sourceChannel);
-    if (message.token !== undefined && message.token !== undefined) {
+    if (message.sourcePort !== '') {
+      writer.uint32(10).string(message.sourcePort);
+    }
+    if (message.sourceChannel !== '') {
+      writer.uint32(18).string(message.sourceChannel);
+    }
+    if (message.token !== undefined) {
       Coin.encode(message.token, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).string(message.sender);
-    writer.uint32(42).string(message.receiver);
-    if (
-      message.timeoutHeight !== undefined &&
-      message.timeoutHeight !== undefined
-    ) {
+    if (message.sender !== '') {
+      writer.uint32(34).string(message.sender);
+    }
+    if (message.receiver !== '') {
+      writer.uint32(42).string(message.receiver);
+    }
+    if (message.timeoutHeight !== undefined) {
       Height.encode(message.timeoutHeight, writer.uint32(50).fork()).ldelim();
     }
-    writer.uint32(56).uint64(message.timeoutTimestamp);
+    if (!message.timeoutTimestamp.isZero()) {
+      writer.uint32(56).uint64(message.timeoutTimestamp);
+    }
     return writer;
   },
 
@@ -146,6 +153,26 @@ export const MsgTransfer = {
     return message;
   },
 
+  toJSON(message: MsgTransfer): unknown {
+    const obj: any = {};
+    message.sourcePort !== undefined && (obj.sourcePort = message.sourcePort);
+    message.sourceChannel !== undefined &&
+      (obj.sourceChannel = message.sourceChannel);
+    message.token !== undefined &&
+      (obj.token = message.token ? Coin.toJSON(message.token) : undefined);
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.receiver !== undefined && (obj.receiver = message.receiver);
+    message.timeoutHeight !== undefined &&
+      (obj.timeoutHeight = message.timeoutHeight
+        ? Height.toJSON(message.timeoutHeight)
+        : undefined);
+    message.timeoutTimestamp !== undefined &&
+      (obj.timeoutTimestamp = (
+        message.timeoutTimestamp || Long.UZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgTransfer>): MsgTransfer {
     const message = { ...baseMsgTransfer } as MsgTransfer;
     if (object.sourcePort !== undefined && object.sourcePort !== null) {
@@ -188,26 +215,6 @@ export const MsgTransfer = {
     }
     return message;
   },
-
-  toJSON(message: MsgTransfer): unknown {
-    const obj: any = {};
-    message.sourcePort !== undefined && (obj.sourcePort = message.sourcePort);
-    message.sourceChannel !== undefined &&
-      (obj.sourceChannel = message.sourceChannel);
-    message.token !== undefined &&
-      (obj.token = message.token ? Coin.toJSON(message.token) : undefined);
-    message.sender !== undefined && (obj.sender = message.sender);
-    message.receiver !== undefined && (obj.receiver = message.receiver);
-    message.timeoutHeight !== undefined &&
-      (obj.timeoutHeight = message.timeoutHeight
-        ? Height.toJSON(message.timeoutHeight)
-        : undefined);
-    message.timeoutTimestamp !== undefined &&
-      (obj.timeoutTimestamp = (
-        message.timeoutTimestamp || Long.UZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const baseMsgTransferResponse: object = {};
@@ -240,14 +247,14 @@ export const MsgTransferResponse = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<MsgTransferResponse>): MsgTransferResponse {
-    const message = { ...baseMsgTransferResponse } as MsgTransferResponse;
-    return message;
-  },
-
   toJSON(_: MsgTransferResponse): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<MsgTransferResponse>): MsgTransferResponse {
+    const message = { ...baseMsgTransferResponse } as MsgTransferResponse;
+    return message;
   },
 };
 

--- a/src/codec/ibc/core/channel/v1/channel.ts
+++ b/src/codec/ibc/core/channel/v1/channel.ts
@@ -235,12 +235,13 @@ export const Channel = {
     message: Channel,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.state);
-    writer.uint32(16).int32(message.ordering);
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.state !== 0) {
+      writer.uint32(8).int32(message.state);
+    }
+    if (message.ordering !== 0) {
+      writer.uint32(16).int32(message.ordering);
+    }
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(26).fork()
@@ -249,7 +250,9 @@ export const Channel = {
     for (const v of message.connectionHops) {
       writer.uint32(34).string(v!);
     }
-    writer.uint32(42).string(message.version);
+    if (message.version !== '') {
+      writer.uint32(42).string(message.version);
+    }
     return writer;
   },
 
@@ -315,6 +318,24 @@ export const Channel = {
     return message;
   },
 
+  toJSON(message: Channel): unknown {
+    const obj: any = {};
+    message.state !== undefined && (obj.state = stateToJSON(message.state));
+    message.ordering !== undefined &&
+      (obj.ordering = orderToJSON(message.ordering));
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    if (message.connectionHops) {
+      obj.connectionHops = message.connectionHops.map((e) => e);
+    } else {
+      obj.connectionHops = [];
+    }
+    message.version !== undefined && (obj.version = message.version);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Channel>): Channel {
     const message = { ...baseChannel } as Channel;
     message.connectionHops = [];
@@ -345,24 +366,6 @@ export const Channel = {
     }
     return message;
   },
-
-  toJSON(message: Channel): unknown {
-    const obj: any = {};
-    message.state !== undefined && (obj.state = stateToJSON(message.state));
-    message.ordering !== undefined &&
-      (obj.ordering = orderToJSON(message.ordering));
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    if (message.connectionHops) {
-      obj.connectionHops = message.connectionHops.map((e) => e);
-    } else {
-      obj.connectionHops = [];
-    }
-    message.version !== undefined && (obj.version = message.version);
-    return obj;
-  },
 };
 
 const baseIdentifiedChannel: object = {
@@ -379,12 +382,13 @@ export const IdentifiedChannel = {
     message: IdentifiedChannel,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.state);
-    writer.uint32(16).int32(message.ordering);
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.state !== 0) {
+      writer.uint32(8).int32(message.state);
+    }
+    if (message.ordering !== 0) {
+      writer.uint32(16).int32(message.ordering);
+    }
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(26).fork()
@@ -393,9 +397,15 @@ export const IdentifiedChannel = {
     for (const v of message.connectionHops) {
       writer.uint32(34).string(v!);
     }
-    writer.uint32(42).string(message.version);
-    writer.uint32(50).string(message.portId);
-    writer.uint32(58).string(message.channelId);
+    if (message.version !== '') {
+      writer.uint32(42).string(message.version);
+    }
+    if (message.portId !== '') {
+      writer.uint32(50).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(58).string(message.channelId);
+    }
     return writer;
   },
 
@@ -477,6 +487,26 @@ export const IdentifiedChannel = {
     return message;
   },
 
+  toJSON(message: IdentifiedChannel): unknown {
+    const obj: any = {};
+    message.state !== undefined && (obj.state = stateToJSON(message.state));
+    message.ordering !== undefined &&
+      (obj.ordering = orderToJSON(message.ordering));
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    if (message.connectionHops) {
+      obj.connectionHops = message.connectionHops.map((e) => e);
+    } else {
+      obj.connectionHops = [];
+    }
+    message.version !== undefined && (obj.version = message.version);
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<IdentifiedChannel>): IdentifiedChannel {
     const message = { ...baseIdentifiedChannel } as IdentifiedChannel;
     message.connectionHops = [];
@@ -517,26 +547,6 @@ export const IdentifiedChannel = {
     }
     return message;
   },
-
-  toJSON(message: IdentifiedChannel): unknown {
-    const obj: any = {};
-    message.state !== undefined && (obj.state = stateToJSON(message.state));
-    message.ordering !== undefined &&
-      (obj.ordering = orderToJSON(message.ordering));
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    if (message.connectionHops) {
-      obj.connectionHops = message.connectionHops.map((e) => e);
-    } else {
-      obj.connectionHops = [];
-    }
-    message.version !== undefined && (obj.version = message.version);
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    return obj;
-  },
 };
 
 const baseCounterparty: object = { portId: '', channelId: '' };
@@ -546,8 +556,12 @@ export const Counterparty = {
     message: Counterparty,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     return writer;
   },
 
@@ -587,6 +601,13 @@ export const Counterparty = {
     return message;
   },
 
+  toJSON(message: Counterparty): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Counterparty>): Counterparty {
     const message = { ...baseCounterparty } as Counterparty;
     if (object.portId !== undefined && object.portId !== null) {
@@ -600,13 +621,6 @@ export const Counterparty = {
       message.channelId = '';
     }
     return message;
-  },
-
-  toJSON(message: Counterparty): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    return obj;
   },
 };
 
@@ -624,19 +638,30 @@ export const Packet = {
     message: Packet,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.sequence);
-    writer.uint32(18).string(message.sourcePort);
-    writer.uint32(26).string(message.sourceChannel);
-    writer.uint32(34).string(message.destinationPort);
-    writer.uint32(42).string(message.destinationChannel);
-    writer.uint32(50).bytes(message.data);
-    if (
-      message.timeoutHeight !== undefined &&
-      message.timeoutHeight !== undefined
-    ) {
+    if (!message.sequence.isZero()) {
+      writer.uint32(8).uint64(message.sequence);
+    }
+    if (message.sourcePort !== '') {
+      writer.uint32(18).string(message.sourcePort);
+    }
+    if (message.sourceChannel !== '') {
+      writer.uint32(26).string(message.sourceChannel);
+    }
+    if (message.destinationPort !== '') {
+      writer.uint32(34).string(message.destinationPort);
+    }
+    if (message.destinationChannel !== '') {
+      writer.uint32(42).string(message.destinationChannel);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(50).bytes(message.data);
+    }
+    if (message.timeoutHeight !== undefined) {
       Height.encode(message.timeoutHeight, writer.uint32(58).fork()).ldelim();
     }
-    writer.uint32(64).uint64(message.timeoutTimestamp);
+    if (!message.timeoutTimestamp.isZero()) {
+      writer.uint32(64).uint64(message.timeoutTimestamp);
+    }
     return writer;
   },
 
@@ -731,6 +756,32 @@ export const Packet = {
     return message;
   },
 
+  toJSON(message: Packet): unknown {
+    const obj: any = {};
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.sourcePort !== undefined && (obj.sourcePort = message.sourcePort);
+    message.sourceChannel !== undefined &&
+      (obj.sourceChannel = message.sourceChannel);
+    message.destinationPort !== undefined &&
+      (obj.destinationPort = message.destinationPort);
+    message.destinationChannel !== undefined &&
+      (obj.destinationChannel = message.destinationChannel);
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.timeoutHeight !== undefined &&
+      (obj.timeoutHeight = message.timeoutHeight
+        ? Height.toJSON(message.timeoutHeight)
+        : undefined);
+    message.timeoutTimestamp !== undefined &&
+      (obj.timeoutTimestamp = (
+        message.timeoutTimestamp || Long.UZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Packet>): Packet {
     const message = { ...basePacket } as Packet;
     if (object.sequence !== undefined && object.sequence !== null) {
@@ -784,32 +835,6 @@ export const Packet = {
     }
     return message;
   },
-
-  toJSON(message: Packet): unknown {
-    const obj: any = {};
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.sourcePort !== undefined && (obj.sourcePort = message.sourcePort);
-    message.sourceChannel !== undefined &&
-      (obj.sourceChannel = message.sourceChannel);
-    message.destinationPort !== undefined &&
-      (obj.destinationPort = message.destinationPort);
-    message.destinationChannel !== undefined &&
-      (obj.destinationChannel = message.destinationChannel);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.timeoutHeight !== undefined &&
-      (obj.timeoutHeight = message.timeoutHeight
-        ? Height.toJSON(message.timeoutHeight)
-        : undefined);
-    message.timeoutTimestamp !== undefined &&
-      (obj.timeoutTimestamp = (
-        message.timeoutTimestamp || Long.UZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const basePacketState: object = {
@@ -823,10 +848,18 @@ export const PacketState = {
     message: PacketState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.sequence);
-    writer.uint32(34).bytes(message.data);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(24).uint64(message.sequence);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(34).bytes(message.data);
+    }
     return writer;
   },
 
@@ -880,6 +913,19 @@ export const PacketState = {
     return message;
   },
 
+  toJSON(message: PacketState): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PacketState>): PacketState {
     const message = { ...basePacketState } as PacketState;
     if (object.portId !== undefined && object.portId !== null) {
@@ -903,19 +949,6 @@ export const PacketState = {
       message.data = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: PacketState): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -969,6 +1002,17 @@ export const Acknowledgement = {
     return message;
   },
 
+  toJSON(message: Acknowledgement): unknown {
+    const obj: any = {};
+    message.result !== undefined &&
+      (obj.result =
+        message.result !== undefined
+          ? base64FromBytes(message.result)
+          : undefined);
+    message.error !== undefined && (obj.error = message.error);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Acknowledgement>): Acknowledgement {
     const message = { ...baseAcknowledgement } as Acknowledgement;
     if (object.result !== undefined && object.result !== null) {
@@ -983,17 +1027,6 @@ export const Acknowledgement = {
     }
     return message;
   },
-
-  toJSON(message: Acknowledgement): unknown {
-    const obj: any = {};
-    message.result !== undefined &&
-      (obj.result =
-        message.result !== undefined
-          ? base64FromBytes(message.result)
-          : undefined);
-    message.error !== undefined && (obj.error = message.error);
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -1003,7 +1036,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/channel/v1/genesis.ts
+++ b/src/codec/ibc/core/channel/v1/genesis.ts
@@ -59,7 +59,9 @@ export const GenesisState = {
     for (const v of message.ackSequences) {
       PacketSequence.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    writer.uint32(64).uint64(message.nextChannelSequence);
+    if (!message.nextChannelSequence.isZero()) {
+      writer.uint32(64).uint64(message.nextChannelSequence);
+    }
     return writer;
   },
 
@@ -177,64 +179,6 @@ export const GenesisState = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<GenesisState>): GenesisState {
-    const message = { ...baseGenesisState } as GenesisState;
-    message.channels = [];
-    message.acknowledgements = [];
-    message.commitments = [];
-    message.receipts = [];
-    message.sendSequences = [];
-    message.recvSequences = [];
-    message.ackSequences = [];
-    if (object.channels !== undefined && object.channels !== null) {
-      for (const e of object.channels) {
-        message.channels.push(IdentifiedChannel.fromPartial(e));
-      }
-    }
-    if (
-      object.acknowledgements !== undefined &&
-      object.acknowledgements !== null
-    ) {
-      for (const e of object.acknowledgements) {
-        message.acknowledgements.push(PacketState.fromPartial(e));
-      }
-    }
-    if (object.commitments !== undefined && object.commitments !== null) {
-      for (const e of object.commitments) {
-        message.commitments.push(PacketState.fromPartial(e));
-      }
-    }
-    if (object.receipts !== undefined && object.receipts !== null) {
-      for (const e of object.receipts) {
-        message.receipts.push(PacketState.fromPartial(e));
-      }
-    }
-    if (object.sendSequences !== undefined && object.sendSequences !== null) {
-      for (const e of object.sendSequences) {
-        message.sendSequences.push(PacketSequence.fromPartial(e));
-      }
-    }
-    if (object.recvSequences !== undefined && object.recvSequences !== null) {
-      for (const e of object.recvSequences) {
-        message.recvSequences.push(PacketSequence.fromPartial(e));
-      }
-    }
-    if (object.ackSequences !== undefined && object.ackSequences !== null) {
-      for (const e of object.ackSequences) {
-        message.ackSequences.push(PacketSequence.fromPartial(e));
-      }
-    }
-    if (
-      object.nextChannelSequence !== undefined &&
-      object.nextChannelSequence !== null
-    ) {
-      message.nextChannelSequence = object.nextChannelSequence as Long;
-    } else {
-      message.nextChannelSequence = Long.UZERO;
-    }
-    return message;
-  },
-
   toJSON(message: GenesisState): unknown {
     const obj: any = {};
     if (message.channels) {
@@ -292,6 +236,64 @@ export const GenesisState = {
       ).toString());
     return obj;
   },
+
+  fromPartial(object: DeepPartial<GenesisState>): GenesisState {
+    const message = { ...baseGenesisState } as GenesisState;
+    message.channels = [];
+    message.acknowledgements = [];
+    message.commitments = [];
+    message.receipts = [];
+    message.sendSequences = [];
+    message.recvSequences = [];
+    message.ackSequences = [];
+    if (object.channels !== undefined && object.channels !== null) {
+      for (const e of object.channels) {
+        message.channels.push(IdentifiedChannel.fromPartial(e));
+      }
+    }
+    if (
+      object.acknowledgements !== undefined &&
+      object.acknowledgements !== null
+    ) {
+      for (const e of object.acknowledgements) {
+        message.acknowledgements.push(PacketState.fromPartial(e));
+      }
+    }
+    if (object.commitments !== undefined && object.commitments !== null) {
+      for (const e of object.commitments) {
+        message.commitments.push(PacketState.fromPartial(e));
+      }
+    }
+    if (object.receipts !== undefined && object.receipts !== null) {
+      for (const e of object.receipts) {
+        message.receipts.push(PacketState.fromPartial(e));
+      }
+    }
+    if (object.sendSequences !== undefined && object.sendSequences !== null) {
+      for (const e of object.sendSequences) {
+        message.sendSequences.push(PacketSequence.fromPartial(e));
+      }
+    }
+    if (object.recvSequences !== undefined && object.recvSequences !== null) {
+      for (const e of object.recvSequences) {
+        message.recvSequences.push(PacketSequence.fromPartial(e));
+      }
+    }
+    if (object.ackSequences !== undefined && object.ackSequences !== null) {
+      for (const e of object.ackSequences) {
+        message.ackSequences.push(PacketSequence.fromPartial(e));
+      }
+    }
+    if (
+      object.nextChannelSequence !== undefined &&
+      object.nextChannelSequence !== null
+    ) {
+      message.nextChannelSequence = object.nextChannelSequence as Long;
+    } else {
+      message.nextChannelSequence = Long.UZERO;
+    }
+    return message;
+  },
 };
 
 const basePacketSequence: object = {
@@ -305,9 +307,15 @@ export const PacketSequence = {
     message: PacketSequence,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.sequence);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(24).uint64(message.sequence);
+    }
     return writer;
   },
 
@@ -355,6 +363,15 @@ export const PacketSequence = {
     return message;
   },
 
+  toJSON(message: PacketSequence): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PacketSequence>): PacketSequence {
     const message = { ...basePacketSequence } as PacketSequence;
     if (object.portId !== undefined && object.portId !== null) {
@@ -373,15 +390,6 @@ export const PacketSequence = {
       message.sequence = Long.UZERO;
     }
     return message;
-  },
-
-  toJSON(message: PacketSequence): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    return obj;
   },
 };
 

--- a/src/codec/ibc/core/channel/v1/query.ts
+++ b/src/codec/ibc/core/channel/v1/query.ts
@@ -344,8 +344,12 @@ export const QueryChannelRequest = {
     message: QueryChannelRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     return writer;
   },
 
@@ -385,6 +389,13 @@ export const QueryChannelRequest = {
     return message;
   },
 
+  toJSON(message: QueryChannelRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<QueryChannelRequest>): QueryChannelRequest {
     const message = { ...baseQueryChannelRequest } as QueryChannelRequest;
     if (object.portId !== undefined && object.portId !== null) {
@@ -399,13 +410,6 @@ export const QueryChannelRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    return obj;
-  },
 };
 
 const baseQueryChannelResponse: object = {};
@@ -415,14 +419,13 @@ export const QueryChannelResponse = {
     message: QueryChannelResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.channel !== undefined && message.channel !== undefined) {
+    if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -473,6 +476,23 @@ export const QueryChannelResponse = {
     return message;
   },
 
+  toJSON(message: QueryChannelResponse): unknown {
+    const obj: any = {};
+    message.channel !== undefined &&
+      (obj.channel = message.channel
+        ? Channel.toJSON(message.channel)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<QueryChannelResponse>): QueryChannelResponse {
     const message = { ...baseQueryChannelResponse } as QueryChannelResponse;
     if (object.channel !== undefined && object.channel !== null) {
@@ -492,23 +512,6 @@ export const QueryChannelResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelResponse): unknown {
-    const obj: any = {};
-    message.channel !== undefined &&
-      (obj.channel = message.channel
-        ? Channel.toJSON(message.channel)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryChannelsRequest: object = {};
@@ -518,7 +521,7 @@ export const QueryChannelsRequest = {
     message: QueryChannelsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -555,6 +558,15 @@ export const QueryChannelsRequest = {
     return message;
   },
 
+  toJSON(message: QueryChannelsRequest): unknown {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<QueryChannelsRequest>): QueryChannelsRequest {
     const message = { ...baseQueryChannelsRequest } as QueryChannelsRequest;
     if (object.pagination !== undefined && object.pagination !== null) {
@@ -563,15 +575,6 @@ export const QueryChannelsRequest = {
       message.pagination = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryChannelsRequest): unknown {
-    const obj: any = {};
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
   },
 };
 
@@ -585,13 +588,13 @@ export const QueryChannelsResponse = {
     for (const v of message.channels) {
       IdentifiedChannel.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -648,6 +651,24 @@ export const QueryChannelsResponse = {
     return message;
   },
 
+  toJSON(message: QueryChannelsResponse): unknown {
+    const obj: any = {};
+    if (message.channels) {
+      obj.channels = message.channels.map((e) =>
+        e ? IdentifiedChannel.toJSON(e) : undefined
+      );
+    } else {
+      obj.channels = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryChannelsResponse>
   ): QueryChannelsResponse {
@@ -670,24 +691,6 @@ export const QueryChannelsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelsResponse): unknown {
-    const obj: any = {};
-    if (message.channels) {
-      obj.channels = message.channels.map((e) =>
-        e ? IdentifiedChannel.toJSON(e) : undefined
-      );
-    } else {
-      obj.channels = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionChannelsRequest: object = { connection: '' };
@@ -697,8 +700,10 @@ export const QueryConnectionChannelsRequest = {
     message: QueryConnectionChannelsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connection);
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.connection !== '') {
+      writer.uint32(10).string(message.connection);
+    }
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -747,6 +752,16 @@ export const QueryConnectionChannelsRequest = {
     return message;
   },
 
+  toJSON(message: QueryConnectionChannelsRequest): unknown {
+    const obj: any = {};
+    message.connection !== undefined && (obj.connection = message.connection);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionChannelsRequest>
   ): QueryConnectionChannelsRequest {
@@ -765,16 +780,6 @@ export const QueryConnectionChannelsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionChannelsRequest): unknown {
-    const obj: any = {};
-    message.connection !== undefined && (obj.connection = message.connection);
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionChannelsResponse: object = {};
@@ -787,13 +792,13 @@ export const QueryConnectionChannelsResponse = {
     for (const v of message.channels) {
       IdentifiedChannel.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -854,6 +859,24 @@ export const QueryConnectionChannelsResponse = {
     return message;
   },
 
+  toJSON(message: QueryConnectionChannelsResponse): unknown {
+    const obj: any = {};
+    if (message.channels) {
+      obj.channels = message.channels.map((e) =>
+        e ? IdentifiedChannel.toJSON(e) : undefined
+      );
+    } else {
+      obj.channels = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionChannelsResponse>
   ): QueryConnectionChannelsResponse {
@@ -878,24 +901,6 @@ export const QueryConnectionChannelsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionChannelsResponse): unknown {
-    const obj: any = {};
-    if (message.channels) {
-      obj.channels = message.channels.map((e) =>
-        e ? IdentifiedChannel.toJSON(e) : undefined
-      );
-    } else {
-      obj.channels = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryChannelClientStateRequest: object = {
@@ -908,8 +913,12 @@ export const QueryChannelClientStateRequest = {
     message: QueryChannelClientStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     return writer;
   },
 
@@ -956,6 +965,13 @@ export const QueryChannelClientStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryChannelClientStateRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryChannelClientStateRequest>
   ): QueryChannelClientStateRequest {
@@ -974,13 +990,6 @@ export const QueryChannelClientStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelClientStateRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    return obj;
-  },
 };
 
 const baseQueryChannelClientStateResponse: object = {};
@@ -990,20 +999,16 @@ export const QueryChannelClientStateResponse = {
     message: QueryChannelClientStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.identifiedClientState !== undefined &&
-      message.identifiedClientState !== undefined
-    ) {
+    if (message.identifiedClientState !== undefined) {
       IdentifiedClientState.encode(
         message.identifiedClientState,
         writer.uint32(10).fork()
       ).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -1066,6 +1071,23 @@ export const QueryChannelClientStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryChannelClientStateResponse): unknown {
+    const obj: any = {};
+    message.identifiedClientState !== undefined &&
+      (obj.identifiedClientState = message.identifiedClientState
+        ? IdentifiedClientState.toJSON(message.identifiedClientState)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryChannelClientStateResponse>
   ): QueryChannelClientStateResponse {
@@ -1094,23 +1116,6 @@ export const QueryChannelClientStateResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelClientStateResponse): unknown {
-    const obj: any = {};
-    message.identifiedClientState !== undefined &&
-      (obj.identifiedClientState = message.identifiedClientState
-        ? IdentifiedClientState.toJSON(message.identifiedClientState)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryChannelConsensusStateRequest: object = {
@@ -1125,10 +1130,18 @@ export const QueryChannelConsensusStateRequest = {
     message: QueryChannelConsensusStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.revisionNumber);
-    writer.uint32(32).uint64(message.revisionHeight);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.revisionNumber.isZero()) {
+      writer.uint32(24).uint64(message.revisionNumber);
+    }
+    if (!message.revisionHeight.isZero()) {
+      writer.uint32(32).uint64(message.revisionHeight);
+    }
     return writer;
   },
 
@@ -1191,6 +1204,17 @@ export const QueryChannelConsensusStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryChannelConsensusStateRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.revisionNumber !== undefined &&
+      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
+    message.revisionHeight !== undefined &&
+      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryChannelConsensusStateRequest>
   ): QueryChannelConsensusStateRequest {
@@ -1219,17 +1243,6 @@ export const QueryChannelConsensusStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelConsensusStateRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.revisionNumber !== undefined &&
-      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
-    message.revisionHeight !== undefined &&
-      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseQueryChannelConsensusStateResponse: object = { clientId: '' };
@@ -1239,18 +1252,16 @@ export const QueryChannelConsensusStateResponse = {
     message: QueryChannelConsensusStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.clientId);
-    writer.uint32(26).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(18).string(message.clientId);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(26).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -1313,6 +1324,24 @@ export const QueryChannelConsensusStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryChannelConsensusStateResponse): unknown {
+    const obj: any = {};
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryChannelConsensusStateResponse>
   ): QueryChannelConsensusStateResponse {
@@ -1341,24 +1370,6 @@ export const QueryChannelConsensusStateResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryChannelConsensusStateResponse): unknown {
-    const obj: any = {};
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketCommitmentRequest: object = {
@@ -1372,9 +1383,15 @@ export const QueryPacketCommitmentRequest = {
     message: QueryPacketCommitmentRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.sequence);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(24).uint64(message.sequence);
+    }
     return writer;
   },
 
@@ -1429,6 +1446,15 @@ export const QueryPacketCommitmentRequest = {
     return message;
   },
 
+  toJSON(message: QueryPacketCommitmentRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketCommitmentRequest>
   ): QueryPacketCommitmentRequest {
@@ -1452,15 +1478,6 @@ export const QueryPacketCommitmentRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketCommitmentRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseQueryPacketCommitmentResponse: object = {};
@@ -1470,12 +1487,13 @@ export const QueryPacketCommitmentResponse = {
     message: QueryPacketCommitmentResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.commitment);
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.commitment.length !== 0) {
+      writer.uint32(10).bytes(message.commitment);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -1528,6 +1546,23 @@ export const QueryPacketCommitmentResponse = {
     return message;
   },
 
+  toJSON(message: QueryPacketCommitmentResponse): unknown {
+    const obj: any = {};
+    message.commitment !== undefined &&
+      (obj.commitment = base64FromBytes(
+        message.commitment !== undefined ? message.commitment : new Uint8Array()
+      ));
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketCommitmentResponse>
   ): QueryPacketCommitmentResponse {
@@ -1551,23 +1586,6 @@ export const QueryPacketCommitmentResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketCommitmentResponse): unknown {
-    const obj: any = {};
-    message.commitment !== undefined &&
-      (obj.commitment = base64FromBytes(
-        message.commitment !== undefined ? message.commitment : new Uint8Array()
-      ));
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketCommitmentsRequest: object = { portId: '', channelId: '' };
@@ -1577,9 +1595,13 @@ export const QueryPacketCommitmentsRequest = {
     message: QueryPacketCommitmentsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -1636,6 +1658,17 @@ export const QueryPacketCommitmentsRequest = {
     return message;
   },
 
+  toJSON(message: QueryPacketCommitmentsRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketCommitmentsRequest>
   ): QueryPacketCommitmentsRequest {
@@ -1659,17 +1692,6 @@ export const QueryPacketCommitmentsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketCommitmentsRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketCommitmentsResponse: object = {};
@@ -1682,13 +1704,13 @@ export const QueryPacketCommitmentsResponse = {
     for (const v of message.commitments) {
       PacketState.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -1747,6 +1769,24 @@ export const QueryPacketCommitmentsResponse = {
     return message;
   },
 
+  toJSON(message: QueryPacketCommitmentsResponse): unknown {
+    const obj: any = {};
+    if (message.commitments) {
+      obj.commitments = message.commitments.map((e) =>
+        e ? PacketState.toJSON(e) : undefined
+      );
+    } else {
+      obj.commitments = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketCommitmentsResponse>
   ): QueryPacketCommitmentsResponse {
@@ -1771,24 +1811,6 @@ export const QueryPacketCommitmentsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketCommitmentsResponse): unknown {
-    const obj: any = {};
-    if (message.commitments) {
-      obj.commitments = message.commitments.map((e) =>
-        e ? PacketState.toJSON(e) : undefined
-      );
-    } else {
-      obj.commitments = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketReceiptRequest: object = {
@@ -1802,9 +1824,15 @@ export const QueryPacketReceiptRequest = {
     message: QueryPacketReceiptRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.sequence);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(24).uint64(message.sequence);
+    }
     return writer;
   },
 
@@ -1859,6 +1887,15 @@ export const QueryPacketReceiptRequest = {
     return message;
   },
 
+  toJSON(message: QueryPacketReceiptRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketReceiptRequest>
   ): QueryPacketReceiptRequest {
@@ -1882,15 +1919,6 @@ export const QueryPacketReceiptRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketReceiptRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseQueryPacketReceiptResponse: object = { received: false };
@@ -1900,12 +1928,13 @@ export const QueryPacketReceiptResponse = {
     message: QueryPacketReceiptResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(16).bool(message.received);
-    writer.uint32(26).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.received === true) {
+      writer.uint32(16).bool(message.received);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(26).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -1960,6 +1989,20 @@ export const QueryPacketReceiptResponse = {
     return message;
   },
 
+  toJSON(message: QueryPacketReceiptResponse): unknown {
+    const obj: any = {};
+    message.received !== undefined && (obj.received = message.received);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketReceiptResponse>
   ): QueryPacketReceiptResponse {
@@ -1983,20 +2026,6 @@ export const QueryPacketReceiptResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketReceiptResponse): unknown {
-    const obj: any = {};
-    message.received !== undefined && (obj.received = message.received);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketAcknowledgementRequest: object = {
@@ -2010,9 +2039,15 @@ export const QueryPacketAcknowledgementRequest = {
     message: QueryPacketAcknowledgementRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(24).uint64(message.sequence);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(24).uint64(message.sequence);
+    }
     return writer;
   },
 
@@ -2067,6 +2102,15 @@ export const QueryPacketAcknowledgementRequest = {
     return message;
   },
 
+  toJSON(message: QueryPacketAcknowledgementRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketAcknowledgementRequest>
   ): QueryPacketAcknowledgementRequest {
@@ -2090,15 +2134,6 @@ export const QueryPacketAcknowledgementRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketAcknowledgementRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseQueryPacketAcknowledgementResponse: object = {};
@@ -2108,12 +2143,13 @@ export const QueryPacketAcknowledgementResponse = {
     message: QueryPacketAcknowledgementResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.acknowledgement);
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.acknowledgement.length !== 0) {
+      writer.uint32(10).bytes(message.acknowledgement);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -2169,6 +2205,25 @@ export const QueryPacketAcknowledgementResponse = {
     return message;
   },
 
+  toJSON(message: QueryPacketAcknowledgementResponse): unknown {
+    const obj: any = {};
+    message.acknowledgement !== undefined &&
+      (obj.acknowledgement = base64FromBytes(
+        message.acknowledgement !== undefined
+          ? message.acknowledgement
+          : new Uint8Array()
+      ));
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketAcknowledgementResponse>
   ): QueryPacketAcknowledgementResponse {
@@ -2195,25 +2250,6 @@ export const QueryPacketAcknowledgementResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketAcknowledgementResponse): unknown {
-    const obj: any = {};
-    message.acknowledgement !== undefined &&
-      (obj.acknowledgement = base64FromBytes(
-        message.acknowledgement !== undefined
-          ? message.acknowledgement
-          : new Uint8Array()
-      ));
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketAcknowledgementsRequest: object = {
@@ -2226,9 +2262,13 @@ export const QueryPacketAcknowledgementsRequest = {
     message: QueryPacketAcknowledgementsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -2285,6 +2325,17 @@ export const QueryPacketAcknowledgementsRequest = {
     return message;
   },
 
+  toJSON(message: QueryPacketAcknowledgementsRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketAcknowledgementsRequest>
   ): QueryPacketAcknowledgementsRequest {
@@ -2308,17 +2359,6 @@ export const QueryPacketAcknowledgementsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketAcknowledgementsRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryPacketAcknowledgementsResponse: object = {};
@@ -2331,13 +2371,13 @@ export const QueryPacketAcknowledgementsResponse = {
     for (const v of message.acknowledgements) {
       PacketState.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -2401,6 +2441,24 @@ export const QueryPacketAcknowledgementsResponse = {
     return message;
   },
 
+  toJSON(message: QueryPacketAcknowledgementsResponse): unknown {
+    const obj: any = {};
+    if (message.acknowledgements) {
+      obj.acknowledgements = message.acknowledgements.map((e) =>
+        e ? PacketState.toJSON(e) : undefined
+      );
+    } else {
+      obj.acknowledgements = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryPacketAcknowledgementsResponse>
   ): QueryPacketAcknowledgementsResponse {
@@ -2428,24 +2486,6 @@ export const QueryPacketAcknowledgementsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryPacketAcknowledgementsResponse): unknown {
-    const obj: any = {};
-    if (message.acknowledgements) {
-      obj.acknowledgements = message.acknowledgements.map((e) =>
-        e ? PacketState.toJSON(e) : undefined
-      );
-    } else {
-      obj.acknowledgements = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryUnreceivedPacketsRequest: object = {
@@ -2459,8 +2499,12 @@ export const QueryUnreceivedPacketsRequest = {
     message: QueryUnreceivedPacketsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     writer.uint32(26).fork();
     for (const v of message.packetCommitmentSequences) {
       writer.uint64(v);
@@ -2532,6 +2576,20 @@ export const QueryUnreceivedPacketsRequest = {
     return message;
   },
 
+  toJSON(message: QueryUnreceivedPacketsRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    if (message.packetCommitmentSequences) {
+      obj.packetCommitmentSequences = message.packetCommitmentSequences.map(
+        (e) => (e || Long.UZERO).toString()
+      );
+    } else {
+      obj.packetCommitmentSequences = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryUnreceivedPacketsRequest>
   ): QueryUnreceivedPacketsRequest {
@@ -2559,20 +2617,6 @@ export const QueryUnreceivedPacketsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryUnreceivedPacketsRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    if (message.packetCommitmentSequences) {
-      obj.packetCommitmentSequences = message.packetCommitmentSequences.map(
-        (e) => (e || Long.UZERO).toString()
-      );
-    } else {
-      obj.packetCommitmentSequences = [];
-    }
-    return obj;
-  },
 };
 
 const baseQueryUnreceivedPacketsResponse: object = { sequences: Long.UZERO };
@@ -2587,7 +2631,7 @@ export const QueryUnreceivedPacketsResponse = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -2645,6 +2689,20 @@ export const QueryUnreceivedPacketsResponse = {
     return message;
   },
 
+  toJSON(message: QueryUnreceivedPacketsResponse): unknown {
+    const obj: any = {};
+    if (message.sequences) {
+      obj.sequences = message.sequences.map((e) =>
+        (e || Long.UZERO).toString()
+      );
+    } else {
+      obj.sequences = [];
+    }
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryUnreceivedPacketsResponse>
   ): QueryUnreceivedPacketsResponse {
@@ -2664,20 +2722,6 @@ export const QueryUnreceivedPacketsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryUnreceivedPacketsResponse): unknown {
-    const obj: any = {};
-    if (message.sequences) {
-      obj.sequences = message.sequences.map((e) =>
-        (e || Long.UZERO).toString()
-      );
-    } else {
-      obj.sequences = [];
-    }
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryUnreceivedAcksRequest: object = {
@@ -2691,8 +2735,12 @@ export const QueryUnreceivedAcksRequest = {
     message: QueryUnreceivedAcksRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     writer.uint32(26).fork();
     for (const v of message.packetAckSequences) {
       writer.uint64(v);
@@ -2764,6 +2812,20 @@ export const QueryUnreceivedAcksRequest = {
     return message;
   },
 
+  toJSON(message: QueryUnreceivedAcksRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    if (message.packetAckSequences) {
+      obj.packetAckSequences = message.packetAckSequences.map((e) =>
+        (e || Long.UZERO).toString()
+      );
+    } else {
+      obj.packetAckSequences = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryUnreceivedAcksRequest>
   ): QueryUnreceivedAcksRequest {
@@ -2791,20 +2853,6 @@ export const QueryUnreceivedAcksRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryUnreceivedAcksRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    if (message.packetAckSequences) {
-      obj.packetAckSequences = message.packetAckSequences.map((e) =>
-        (e || Long.UZERO).toString()
-      );
-    } else {
-      obj.packetAckSequences = [];
-    }
-    return obj;
-  },
 };
 
 const baseQueryUnreceivedAcksResponse: object = { sequences: Long.UZERO };
@@ -2819,7 +2867,7 @@ export const QueryUnreceivedAcksResponse = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -2877,6 +2925,20 @@ export const QueryUnreceivedAcksResponse = {
     return message;
   },
 
+  toJSON(message: QueryUnreceivedAcksResponse): unknown {
+    const obj: any = {};
+    if (message.sequences) {
+      obj.sequences = message.sequences.map((e) =>
+        (e || Long.UZERO).toString()
+      );
+    } else {
+      obj.sequences = [];
+    }
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryUnreceivedAcksResponse>
   ): QueryUnreceivedAcksResponse {
@@ -2896,20 +2958,6 @@ export const QueryUnreceivedAcksResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryUnreceivedAcksResponse): unknown {
-    const obj: any = {};
-    if (message.sequences) {
-      obj.sequences = message.sequences.map((e) =>
-        (e || Long.UZERO).toString()
-      );
-    } else {
-      obj.sequences = [];
-    }
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryNextSequenceReceiveRequest: object = {
@@ -2922,8 +2970,12 @@ export const QueryNextSequenceReceiveRequest = {
     message: QueryNextSequenceReceiveRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
     return writer;
   },
 
@@ -2970,6 +3022,13 @@ export const QueryNextSequenceReceiveRequest = {
     return message;
   },
 
+  toJSON(message: QueryNextSequenceReceiveRequest): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryNextSequenceReceiveRequest>
   ): QueryNextSequenceReceiveRequest {
@@ -2988,13 +3047,6 @@ export const QueryNextSequenceReceiveRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryNextSequenceReceiveRequest): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    return obj;
-  },
 };
 
 const baseQueryNextSequenceReceiveResponse: object = {
@@ -3006,12 +3058,13 @@ export const QueryNextSequenceReceiveResponse = {
     message: QueryNextSequenceReceiveResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.nextSequenceReceive);
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (!message.nextSequenceReceive.isZero()) {
+      writer.uint32(8).uint64(message.nextSequenceReceive);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -3069,6 +3122,23 @@ export const QueryNextSequenceReceiveResponse = {
     return message;
   },
 
+  toJSON(message: QueryNextSequenceReceiveResponse): unknown {
+    const obj: any = {};
+    message.nextSequenceReceive !== undefined &&
+      (obj.nextSequenceReceive = (
+        message.nextSequenceReceive || Long.UZERO
+      ).toString());
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryNextSequenceReceiveResponse>
   ): QueryNextSequenceReceiveResponse {
@@ -3094,23 +3164,6 @@ export const QueryNextSequenceReceiveResponse = {
       message.proofHeight = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryNextSequenceReceiveResponse): unknown {
-    const obj: any = {};
-    message.nextSequenceReceive !== undefined &&
-      (obj.nextSequenceReceive = (
-        message.nextSequenceReceive || Long.UZERO
-      ).toString());
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
   },
 };
 
@@ -3386,7 +3439,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/channel/v1/tx.ts
+++ b/src/codec/ibc/core/channel/v1/tx.ts
@@ -155,11 +155,15 @@ export const MsgChannelOpenInit = {
     message: MsgChannelOpenInit,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    if (message.channel !== undefined && message.channel !== undefined) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(26).string(message.signer);
+    }
     return writer;
   },
 
@@ -207,6 +211,17 @@ export const MsgChannelOpenInit = {
     return message;
   },
 
+  toJSON(message: MsgChannelOpenInit): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channel !== undefined &&
+      (obj.channel = message.channel
+        ? Channel.toJSON(message.channel)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgChannelOpenInit>): MsgChannelOpenInit {
     const message = { ...baseMsgChannelOpenInit } as MsgChannelOpenInit;
     if (object.portId !== undefined && object.portId !== null) {
@@ -225,17 +240,6 @@ export const MsgChannelOpenInit = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgChannelOpenInit): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channel !== undefined &&
-      (obj.channel = message.channel
-        ? Channel.toJSON(message.channel)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -276,6 +280,11 @@ export const MsgChannelOpenInitResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelOpenInitResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelOpenInitResponse>
   ): MsgChannelOpenInitResponse {
@@ -283,11 +292,6 @@ export const MsgChannelOpenInitResponse = {
       ...baseMsgChannelOpenInitResponse,
     } as MsgChannelOpenInitResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelOpenInitResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -303,20 +307,27 @@ export const MsgChannelOpenTry = {
     message: MsgChannelOpenTry,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.previousChannelId);
-    if (message.channel !== undefined && message.channel !== undefined) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.previousChannelId !== '') {
+      writer.uint32(18).string(message.previousChannelId);
+    }
+    if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).string(message.counterpartyVersion);
-    writer.uint32(42).bytes(message.proofInit);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.counterpartyVersion !== '') {
+      writer.uint32(34).string(message.counterpartyVersion);
+    }
+    if (message.proofInit.length !== 0) {
+      writer.uint32(42).bytes(message.proofInit);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(50).fork()).ldelim();
     }
-    writer.uint32(58).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(58).string(message.signer);
+    }
     return writer;
   },
 
@@ -400,6 +411,29 @@ export const MsgChannelOpenTry = {
     return message;
   },
 
+  toJSON(message: MsgChannelOpenTry): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.previousChannelId !== undefined &&
+      (obj.previousChannelId = message.previousChannelId);
+    message.channel !== undefined &&
+      (obj.channel = message.channel
+        ? Channel.toJSON(message.channel)
+        : undefined);
+    message.counterpartyVersion !== undefined &&
+      (obj.counterpartyVersion = message.counterpartyVersion);
+    message.proofInit !== undefined &&
+      (obj.proofInit = base64FromBytes(
+        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgChannelOpenTry>): MsgChannelOpenTry {
     const message = { ...baseMsgChannelOpenTry } as MsgChannelOpenTry;
     if (object.portId !== undefined && object.portId !== null) {
@@ -445,29 +479,6 @@ export const MsgChannelOpenTry = {
     }
     return message;
   },
-
-  toJSON(message: MsgChannelOpenTry): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.previousChannelId !== undefined &&
-      (obj.previousChannelId = message.previousChannelId);
-    message.channel !== undefined &&
-      (obj.channel = message.channel
-        ? Channel.toJSON(message.channel)
-        : undefined);
-    message.counterpartyVersion !== undefined &&
-      (obj.counterpartyVersion = message.counterpartyVersion);
-    message.proofInit !== undefined &&
-      (obj.proofInit = base64FromBytes(
-        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgChannelOpenTryResponse: object = {};
@@ -507,6 +518,11 @@ export const MsgChannelOpenTryResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelOpenTryResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelOpenTryResponse>
   ): MsgChannelOpenTryResponse {
@@ -514,11 +530,6 @@ export const MsgChannelOpenTryResponse = {
       ...baseMsgChannelOpenTryResponse,
     } as MsgChannelOpenTryResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelOpenTryResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -535,18 +546,27 @@ export const MsgChannelOpenAck = {
     message: MsgChannelOpenAck,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(26).string(message.counterpartyChannelId);
-    writer.uint32(34).string(message.counterpartyVersion);
-    writer.uint32(42).bytes(message.proofTry);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.counterpartyChannelId !== '') {
+      writer.uint32(26).string(message.counterpartyChannelId);
+    }
+    if (message.counterpartyVersion !== '') {
+      writer.uint32(34).string(message.counterpartyVersion);
+    }
+    if (message.proofTry.length !== 0) {
+      writer.uint32(42).bytes(message.proofTry);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(50).fork()).ldelim();
     }
-    writer.uint32(58).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(58).string(message.signer);
+    }
     return writer;
   },
 
@@ -630,6 +650,26 @@ export const MsgChannelOpenAck = {
     return message;
   },
 
+  toJSON(message: MsgChannelOpenAck): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.counterpartyChannelId !== undefined &&
+      (obj.counterpartyChannelId = message.counterpartyChannelId);
+    message.counterpartyVersion !== undefined &&
+      (obj.counterpartyVersion = message.counterpartyVersion);
+    message.proofTry !== undefined &&
+      (obj.proofTry = base64FromBytes(
+        message.proofTry !== undefined ? message.proofTry : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgChannelOpenAck>): MsgChannelOpenAck {
     const message = { ...baseMsgChannelOpenAck } as MsgChannelOpenAck;
     if (object.portId !== undefined && object.portId !== null) {
@@ -675,26 +715,6 @@ export const MsgChannelOpenAck = {
     }
     return message;
   },
-
-  toJSON(message: MsgChannelOpenAck): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.counterpartyChannelId !== undefined &&
-      (obj.counterpartyChannelId = message.counterpartyChannelId);
-    message.counterpartyVersion !== undefined &&
-      (obj.counterpartyVersion = message.counterpartyVersion);
-    message.proofTry !== undefined &&
-      (obj.proofTry = base64FromBytes(
-        message.proofTry !== undefined ? message.proofTry : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgChannelOpenAckResponse: object = {};
@@ -734,6 +754,11 @@ export const MsgChannelOpenAckResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelOpenAckResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelOpenAckResponse>
   ): MsgChannelOpenAckResponse {
@@ -741,11 +766,6 @@ export const MsgChannelOpenAckResponse = {
       ...baseMsgChannelOpenAckResponse,
     } as MsgChannelOpenAckResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelOpenAckResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -760,16 +780,21 @@ export const MsgChannelOpenConfirm = {
     message: MsgChannelOpenConfirm,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(26).bytes(message.proofAck);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.proofAck.length !== 0) {
+      writer.uint32(26).bytes(message.proofAck);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(42).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(42).string(message.signer);
+    }
     return writer;
   },
 
@@ -834,6 +859,22 @@ export const MsgChannelOpenConfirm = {
     return message;
   },
 
+  toJSON(message: MsgChannelOpenConfirm): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.proofAck !== undefined &&
+      (obj.proofAck = base64FromBytes(
+        message.proofAck !== undefined ? message.proofAck : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<MsgChannelOpenConfirm>
   ): MsgChannelOpenConfirm {
@@ -864,22 +905,6 @@ export const MsgChannelOpenConfirm = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgChannelOpenConfirm): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.proofAck !== undefined &&
-      (obj.proofAck = base64FromBytes(
-        message.proofAck !== undefined ? message.proofAck : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -920,6 +945,11 @@ export const MsgChannelOpenConfirmResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelOpenConfirmResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelOpenConfirmResponse>
   ): MsgChannelOpenConfirmResponse {
@@ -927,11 +957,6 @@ export const MsgChannelOpenConfirmResponse = {
       ...baseMsgChannelOpenConfirmResponse,
     } as MsgChannelOpenConfirmResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelOpenConfirmResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -946,9 +971,15 @@ export const MsgChannelCloseInit = {
     message: MsgChannelCloseInit,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(26).string(message.signer);
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.signer !== '') {
+      writer.uint32(26).string(message.signer);
+    }
     return writer;
   },
 
@@ -996,6 +1027,14 @@ export const MsgChannelCloseInit = {
     return message;
   },
 
+  toJSON(message: MsgChannelCloseInit): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgChannelCloseInit>): MsgChannelCloseInit {
     const message = { ...baseMsgChannelCloseInit } as MsgChannelCloseInit;
     if (object.portId !== undefined && object.portId !== null) {
@@ -1014,14 +1053,6 @@ export const MsgChannelCloseInit = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgChannelCloseInit): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -1062,6 +1093,11 @@ export const MsgChannelCloseInitResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelCloseInitResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelCloseInitResponse>
   ): MsgChannelCloseInitResponse {
@@ -1069,11 +1105,6 @@ export const MsgChannelCloseInitResponse = {
       ...baseMsgChannelCloseInitResponse,
     } as MsgChannelCloseInitResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelCloseInitResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -1088,16 +1119,21 @@ export const MsgChannelCloseConfirm = {
     message: MsgChannelCloseConfirm,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.portId);
-    writer.uint32(18).string(message.channelId);
-    writer.uint32(26).bytes(message.proofInit);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.portId !== '') {
+      writer.uint32(10).string(message.portId);
+    }
+    if (message.channelId !== '') {
+      writer.uint32(18).string(message.channelId);
+    }
+    if (message.proofInit.length !== 0) {
+      writer.uint32(26).bytes(message.proofInit);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(42).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(42).string(message.signer);
+    }
     return writer;
   },
 
@@ -1162,6 +1198,22 @@ export const MsgChannelCloseConfirm = {
     return message;
   },
 
+  toJSON(message: MsgChannelCloseConfirm): unknown {
+    const obj: any = {};
+    message.portId !== undefined && (obj.portId = message.portId);
+    message.channelId !== undefined && (obj.channelId = message.channelId);
+    message.proofInit !== undefined &&
+      (obj.proofInit = base64FromBytes(
+        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<MsgChannelCloseConfirm>
   ): MsgChannelCloseConfirm {
@@ -1192,22 +1244,6 @@ export const MsgChannelCloseConfirm = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgChannelCloseConfirm): unknown {
-    const obj: any = {};
-    message.portId !== undefined && (obj.portId = message.portId);
-    message.channelId !== undefined && (obj.channelId = message.channelId);
-    message.proofInit !== undefined &&
-      (obj.proofInit = base64FromBytes(
-        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -1248,6 +1284,11 @@ export const MsgChannelCloseConfirmResponse = {
     return message;
   },
 
+  toJSON(_: MsgChannelCloseConfirmResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgChannelCloseConfirmResponse>
   ): MsgChannelCloseConfirmResponse {
@@ -1255,11 +1296,6 @@ export const MsgChannelCloseConfirmResponse = {
       ...baseMsgChannelCloseConfirmResponse,
     } as MsgChannelCloseConfirmResponse;
     return message;
-  },
-
-  toJSON(_: MsgChannelCloseConfirmResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -1270,17 +1306,18 @@ export const MsgRecvPacket = {
     message: MsgRecvPacket,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.packet !== undefined && message.packet !== undefined) {
+    if (message.packet !== undefined) {
       Packet.encode(message.packet, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proofCommitment);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proofCommitment.length !== 0) {
+      writer.uint32(18).bytes(message.proofCommitment);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(34).string(message.signer);
+    }
     return writer;
   },
 
@@ -1337,6 +1374,24 @@ export const MsgRecvPacket = {
     return message;
   },
 
+  toJSON(message: MsgRecvPacket): unknown {
+    const obj: any = {};
+    message.packet !== undefined &&
+      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
+    message.proofCommitment !== undefined &&
+      (obj.proofCommitment = base64FromBytes(
+        message.proofCommitment !== undefined
+          ? message.proofCommitment
+          : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgRecvPacket>): MsgRecvPacket {
     const message = { ...baseMsgRecvPacket } as MsgRecvPacket;
     if (object.packet !== undefined && object.packet !== null) {
@@ -1363,24 +1418,6 @@ export const MsgRecvPacket = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgRecvPacket): unknown {
-    const obj: any = {};
-    message.packet !== undefined &&
-      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
-    message.proofCommitment !== undefined &&
-      (obj.proofCommitment = base64FromBytes(
-        message.proofCommitment !== undefined
-          ? message.proofCommitment
-          : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -1417,14 +1454,14 @@ export const MsgRecvPacketResponse = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<MsgRecvPacketResponse>): MsgRecvPacketResponse {
-    const message = { ...baseMsgRecvPacketResponse } as MsgRecvPacketResponse;
-    return message;
-  },
-
   toJSON(_: MsgRecvPacketResponse): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<MsgRecvPacketResponse>): MsgRecvPacketResponse {
+    const message = { ...baseMsgRecvPacketResponse } as MsgRecvPacketResponse;
+    return message;
   },
 };
 
@@ -1435,18 +1472,21 @@ export const MsgTimeout = {
     message: MsgTimeout,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.packet !== undefined && message.packet !== undefined) {
+    if (message.packet !== undefined) {
       Packet.encode(message.packet, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proofUnreceived);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proofUnreceived.length !== 0) {
+      writer.uint32(18).bytes(message.proofUnreceived);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(32).uint64(message.nextSequenceRecv);
-    writer.uint32(42).string(message.signer);
+    if (!message.nextSequenceRecv.isZero()) {
+      writer.uint32(32).uint64(message.nextSequenceRecv);
+    }
+    if (message.signer !== '') {
+      writer.uint32(42).string(message.signer);
+    }
     return writer;
   },
 
@@ -1514,6 +1554,28 @@ export const MsgTimeout = {
     return message;
   },
 
+  toJSON(message: MsgTimeout): unknown {
+    const obj: any = {};
+    message.packet !== undefined &&
+      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
+    message.proofUnreceived !== undefined &&
+      (obj.proofUnreceived = base64FromBytes(
+        message.proofUnreceived !== undefined
+          ? message.proofUnreceived
+          : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.nextSequenceRecv !== undefined &&
+      (obj.nextSequenceRecv = (
+        message.nextSequenceRecv || Long.UZERO
+      ).toString());
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgTimeout>): MsgTimeout {
     const message = { ...baseMsgTimeout } as MsgTimeout;
     if (object.packet !== undefined && object.packet !== null) {
@@ -1549,28 +1611,6 @@ export const MsgTimeout = {
     }
     return message;
   },
-
-  toJSON(message: MsgTimeout): unknown {
-    const obj: any = {};
-    message.packet !== undefined &&
-      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
-    message.proofUnreceived !== undefined &&
-      (obj.proofUnreceived = base64FromBytes(
-        message.proofUnreceived !== undefined
-          ? message.proofUnreceived
-          : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.nextSequenceRecv !== undefined &&
-      (obj.nextSequenceRecv = (
-        message.nextSequenceRecv || Long.UZERO
-      ).toString());
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgTimeoutResponse: object = {};
@@ -1603,14 +1643,14 @@ export const MsgTimeoutResponse = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<MsgTimeoutResponse>): MsgTimeoutResponse {
-    const message = { ...baseMsgTimeoutResponse } as MsgTimeoutResponse;
-    return message;
-  },
-
   toJSON(_: MsgTimeoutResponse): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<MsgTimeoutResponse>): MsgTimeoutResponse {
+    const message = { ...baseMsgTimeoutResponse } as MsgTimeoutResponse;
+    return message;
   },
 };
 
@@ -1624,19 +1664,24 @@ export const MsgTimeoutOnClose = {
     message: MsgTimeoutOnClose,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.packet !== undefined && message.packet !== undefined) {
+    if (message.packet !== undefined) {
       Packet.encode(message.packet, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proofUnreceived);
-    writer.uint32(26).bytes(message.proofClose);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proofUnreceived.length !== 0) {
+      writer.uint32(18).bytes(message.proofUnreceived);
+    }
+    if (message.proofClose.length !== 0) {
+      writer.uint32(26).bytes(message.proofClose);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(40).uint64(message.nextSequenceRecv);
-    writer.uint32(50).string(message.signer);
+    if (!message.nextSequenceRecv.isZero()) {
+      writer.uint32(40).uint64(message.nextSequenceRecv);
+    }
+    if (message.signer !== '') {
+      writer.uint32(50).string(message.signer);
+    }
     return writer;
   },
 
@@ -1710,6 +1755,32 @@ export const MsgTimeoutOnClose = {
     return message;
   },
 
+  toJSON(message: MsgTimeoutOnClose): unknown {
+    const obj: any = {};
+    message.packet !== undefined &&
+      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
+    message.proofUnreceived !== undefined &&
+      (obj.proofUnreceived = base64FromBytes(
+        message.proofUnreceived !== undefined
+          ? message.proofUnreceived
+          : new Uint8Array()
+      ));
+    message.proofClose !== undefined &&
+      (obj.proofClose = base64FromBytes(
+        message.proofClose !== undefined ? message.proofClose : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.nextSequenceRecv !== undefined &&
+      (obj.nextSequenceRecv = (
+        message.nextSequenceRecv || Long.UZERO
+      ).toString());
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgTimeoutOnClose>): MsgTimeoutOnClose {
     const message = { ...baseMsgTimeoutOnClose } as MsgTimeoutOnClose;
     if (object.packet !== undefined && object.packet !== null) {
@@ -1750,32 +1821,6 @@ export const MsgTimeoutOnClose = {
     }
     return message;
   },
-
-  toJSON(message: MsgTimeoutOnClose): unknown {
-    const obj: any = {};
-    message.packet !== undefined &&
-      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
-    message.proofUnreceived !== undefined &&
-      (obj.proofUnreceived = base64FromBytes(
-        message.proofUnreceived !== undefined
-          ? message.proofUnreceived
-          : new Uint8Array()
-      ));
-    message.proofClose !== undefined &&
-      (obj.proofClose = base64FromBytes(
-        message.proofClose !== undefined ? message.proofClose : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.nextSequenceRecv !== undefined &&
-      (obj.nextSequenceRecv = (
-        message.nextSequenceRecv || Long.UZERO
-      ).toString());
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgTimeoutOnCloseResponse: object = {};
@@ -1815,6 +1860,11 @@ export const MsgTimeoutOnCloseResponse = {
     return message;
   },
 
+  toJSON(_: MsgTimeoutOnCloseResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgTimeoutOnCloseResponse>
   ): MsgTimeoutOnCloseResponse {
@@ -1822,11 +1872,6 @@ export const MsgTimeoutOnCloseResponse = {
       ...baseMsgTimeoutOnCloseResponse,
     } as MsgTimeoutOnCloseResponse;
     return message;
-  },
-
-  toJSON(_: MsgTimeoutOnCloseResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -1837,18 +1882,21 @@ export const MsgAcknowledgement = {
     message: MsgAcknowledgement,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.packet !== undefined && message.packet !== undefined) {
+    if (message.packet !== undefined) {
       Packet.encode(message.packet, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.acknowledgement);
-    writer.uint32(26).bytes(message.proofAcked);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.acknowledgement.length !== 0) {
+      writer.uint32(18).bytes(message.acknowledgement);
+    }
+    if (message.proofAcked.length !== 0) {
+      writer.uint32(26).bytes(message.proofAcked);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(42).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(42).string(message.signer);
+    }
     return writer;
   },
 
@@ -1911,6 +1959,28 @@ export const MsgAcknowledgement = {
     return message;
   },
 
+  toJSON(message: MsgAcknowledgement): unknown {
+    const obj: any = {};
+    message.packet !== undefined &&
+      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
+    message.acknowledgement !== undefined &&
+      (obj.acknowledgement = base64FromBytes(
+        message.acknowledgement !== undefined
+          ? message.acknowledgement
+          : new Uint8Array()
+      ));
+    message.proofAcked !== undefined &&
+      (obj.proofAcked = base64FromBytes(
+        message.proofAcked !== undefined ? message.proofAcked : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgAcknowledgement>): MsgAcknowledgement {
     const message = { ...baseMsgAcknowledgement } as MsgAcknowledgement;
     if (object.packet !== undefined && object.packet !== null) {
@@ -1942,28 +2012,6 @@ export const MsgAcknowledgement = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgAcknowledgement): unknown {
-    const obj: any = {};
-    message.packet !== undefined &&
-      (obj.packet = message.packet ? Packet.toJSON(message.packet) : undefined);
-    message.acknowledgement !== undefined &&
-      (obj.acknowledgement = base64FromBytes(
-        message.acknowledgement !== undefined
-          ? message.acknowledgement
-          : new Uint8Array()
-      ));
-    message.proofAcked !== undefined &&
-      (obj.proofAcked = base64FromBytes(
-        message.proofAcked !== undefined ? message.proofAcked : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -2004,6 +2052,11 @@ export const MsgAcknowledgementResponse = {
     return message;
   },
 
+  toJSON(_: MsgAcknowledgementResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgAcknowledgementResponse>
   ): MsgAcknowledgementResponse {
@@ -2011,11 +2064,6 @@ export const MsgAcknowledgementResponse = {
       ...baseMsgAcknowledgementResponse,
     } as MsgAcknowledgementResponse;
     return message;
-  },
-
-  toJSON(_: MsgAcknowledgementResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -2216,7 +2264,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/client/v1/client.ts
+++ b/src/codec/ibc/core/client/v1/client.ts
@@ -473,8 +473,6 @@ export const Height = {
     message: Height,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    console.log(`encode: ${message}`);
-    console.log(`encode: ${message.revisionNumber} ${typeof message.revisionNumber}`);
     if (!message.revisionNumber.isZero()) {
       writer.uint32(8).uint64(message.revisionNumber);
     }

--- a/src/codec/ibc/core/client/v1/client.ts
+++ b/src/codec/ibc/core/client/v1/client.ts
@@ -473,6 +473,8 @@ export const Height = {
     message: Height,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
+    console.log(`encode: ${message}`);
+    console.log(`encode: ${message.revisionNumber} ${typeof message.revisionNumber}`);
     if (!message.revisionNumber.isZero()) {
       writer.uint32(8).uint64(message.revisionNumber);
     }

--- a/src/codec/ibc/core/client/v1/client.ts
+++ b/src/codec/ibc/core/client/v1/client.ts
@@ -82,11 +82,10 @@ export const IdentifiedClientState = {
     message: IdentifiedClientState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -131,6 +130,16 @@ export const IdentifiedClientState = {
     return message;
   },
 
+  toJSON(message: IdentifiedClientState): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<IdentifiedClientState>
   ): IdentifiedClientState {
@@ -147,16 +156,6 @@ export const IdentifiedClientState = {
     }
     return message;
   },
-
-  toJSON(message: IdentifiedClientState): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseConsensusStateWithHeight: object = {};
@@ -166,13 +165,10 @@ export const ConsensusStateWithHeight = {
     message: ConsensusStateWithHeight,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(10).fork()).ldelim();
     }
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -221,6 +217,17 @@ export const ConsensusStateWithHeight = {
     return message;
   },
 
+  toJSON(message: ConsensusStateWithHeight): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ConsensusStateWithHeight>
   ): ConsensusStateWithHeight {
@@ -239,17 +246,6 @@ export const ConsensusStateWithHeight = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusStateWithHeight): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseClientConsensusStates: object = { clientId: '' };
@@ -259,7 +255,9 @@ export const ClientConsensusStates = {
     message: ClientConsensusStates,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     for (const v of message.consensusStates) {
       ConsensusStateWithHeight.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -312,6 +310,19 @@ export const ClientConsensusStates = {
     return message;
   },
 
+  toJSON(message: ClientConsensusStates): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    if (message.consensusStates) {
+      obj.consensusStates = message.consensusStates.map((e) =>
+        e ? ConsensusStateWithHeight.toJSON(e) : undefined
+      );
+    } else {
+      obj.consensusStates = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ClientConsensusStates>
   ): ClientConsensusStates {
@@ -332,19 +343,6 @@ export const ClientConsensusStates = {
     }
     return message;
   },
-
-  toJSON(message: ClientConsensusStates): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    if (message.consensusStates) {
-      obj.consensusStates = message.consensusStates.map((e) =>
-        e ? ConsensusStateWithHeight.toJSON(e) : undefined
-      );
-    } else {
-      obj.consensusStates = [];
-    }
-    return obj;
-  },
 };
 
 const baseClientUpdateProposal: object = {
@@ -358,10 +356,16 @@ export const ClientUpdateProposal = {
     message: ClientUpdateProposal,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.title);
-    writer.uint32(18).string(message.description);
-    writer.uint32(26).string(message.clientId);
-    if (message.header !== undefined && message.header !== undefined) {
+    if (message.title !== '') {
+      writer.uint32(10).string(message.title);
+    }
+    if (message.description !== '') {
+      writer.uint32(18).string(message.description);
+    }
+    if (message.clientId !== '') {
+      writer.uint32(26).string(message.clientId);
+    }
+    if (message.header !== undefined) {
       Any.encode(message.header, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -422,6 +426,17 @@ export const ClientUpdateProposal = {
     return message;
   },
 
+  toJSON(message: ClientUpdateProposal): unknown {
+    const obj: any = {};
+    message.title !== undefined && (obj.title = message.title);
+    message.description !== undefined &&
+      (obj.description = message.description);
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.header !== undefined &&
+      (obj.header = message.header ? Any.toJSON(message.header) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientUpdateProposal>): ClientUpdateProposal {
     const message = { ...baseClientUpdateProposal } as ClientUpdateProposal;
     if (object.title !== undefined && object.title !== null) {
@@ -446,17 +461,6 @@ export const ClientUpdateProposal = {
     }
     return message;
   },
-
-  toJSON(message: ClientUpdateProposal): unknown {
-    const obj: any = {};
-    message.title !== undefined && (obj.title = message.title);
-    message.description !== undefined &&
-      (obj.description = message.description);
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.header !== undefined &&
-      (obj.header = message.header ? Any.toJSON(message.header) : undefined);
-    return obj;
-  },
 };
 
 const baseHeight: object = {
@@ -469,8 +473,12 @@ export const Height = {
     message: Height,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.revisionNumber);
-    writer.uint32(16).uint64(message.revisionHeight);
+    if (!message.revisionNumber.isZero()) {
+      writer.uint32(8).uint64(message.revisionNumber);
+    }
+    if (!message.revisionHeight.isZero()) {
+      writer.uint32(16).uint64(message.revisionHeight);
+    }
     return writer;
   },
 
@@ -510,6 +518,15 @@ export const Height = {
     return message;
   },
 
+  toJSON(message: Height): unknown {
+    const obj: any = {};
+    message.revisionNumber !== undefined &&
+      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
+    message.revisionHeight !== undefined &&
+      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Height>): Height {
     const message = { ...baseHeight } as Height;
     if (object.revisionNumber !== undefined && object.revisionNumber !== null) {
@@ -523,15 +540,6 @@ export const Height = {
       message.revisionHeight = Long.UZERO;
     }
     return message;
-  },
-
-  toJSON(message: Height): unknown {
-    const obj: any = {};
-    message.revisionNumber !== undefined &&
-      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
-    message.revisionHeight !== undefined &&
-      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
-    return obj;
   },
 };
 
@@ -578,6 +586,16 @@ export const Params = {
     return message;
   },
 
+  toJSON(message: Params): unknown {
+    const obj: any = {};
+    if (message.allowedClients) {
+      obj.allowedClients = message.allowedClients.map((e) => e);
+    } else {
+      obj.allowedClients = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Params>): Params {
     const message = { ...baseParams } as Params;
     message.allowedClients = [];
@@ -587,16 +605,6 @@ export const Params = {
       }
     }
     return message;
-  },
-
-  toJSON(message: Params): unknown {
-    const obj: any = {};
-    if (message.allowedClients) {
-      obj.allowedClients = message.allowedClients.map((e) => e);
-    } else {
-      obj.allowedClients = [];
-    }
-    return obj;
   },
 };
 

--- a/src/codec/ibc/core/client/v1/genesis.ts
+++ b/src/codec/ibc/core/client/v1/genesis.ts
@@ -60,11 +60,15 @@ export const GenesisState = {
     for (const v of message.clientsMetadata) {
       IdentifiedGenesisMetadata.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.params !== undefined && message.params !== undefined) {
+    if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(40).bool(message.createLocalhost);
-    writer.uint32(48).uint64(message.nextClientSequence);
+    if (message.createLocalhost === true) {
+      writer.uint32(40).bool(message.createLocalhost);
+    }
+    if (!message.nextClientSequence.isZero()) {
+      writer.uint32(48).uint64(message.nextClientSequence);
+    }
     return writer;
   },
 
@@ -160,6 +164,40 @@ export const GenesisState = {
     return message;
   },
 
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    if (message.clients) {
+      obj.clients = message.clients.map((e) =>
+        e ? IdentifiedClientState.toJSON(e) : undefined
+      );
+    } else {
+      obj.clients = [];
+    }
+    if (message.clientsConsensus) {
+      obj.clientsConsensus = message.clientsConsensus.map((e) =>
+        e ? ClientConsensusStates.toJSON(e) : undefined
+      );
+    } else {
+      obj.clientsConsensus = [];
+    }
+    if (message.clientsMetadata) {
+      obj.clientsMetadata = message.clientsMetadata.map((e) =>
+        e ? IdentifiedGenesisMetadata.toJSON(e) : undefined
+      );
+    } else {
+      obj.clientsMetadata = [];
+    }
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    message.createLocalhost !== undefined &&
+      (obj.createLocalhost = message.createLocalhost);
+    message.nextClientSequence !== undefined &&
+      (obj.nextClientSequence = (
+        message.nextClientSequence || Long.UZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<GenesisState>): GenesisState {
     const message = { ...baseGenesisState } as GenesisState;
     message.clients = [];
@@ -209,40 +247,6 @@ export const GenesisState = {
     }
     return message;
   },
-
-  toJSON(message: GenesisState): unknown {
-    const obj: any = {};
-    if (message.clients) {
-      obj.clients = message.clients.map((e) =>
-        e ? IdentifiedClientState.toJSON(e) : undefined
-      );
-    } else {
-      obj.clients = [];
-    }
-    if (message.clientsConsensus) {
-      obj.clientsConsensus = message.clientsConsensus.map((e) =>
-        e ? ClientConsensusStates.toJSON(e) : undefined
-      );
-    } else {
-      obj.clientsConsensus = [];
-    }
-    if (message.clientsMetadata) {
-      obj.clientsMetadata = message.clientsMetadata.map((e) =>
-        e ? IdentifiedGenesisMetadata.toJSON(e) : undefined
-      );
-    } else {
-      obj.clientsMetadata = [];
-    }
-    message.params !== undefined &&
-      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
-    message.createLocalhost !== undefined &&
-      (obj.createLocalhost = message.createLocalhost);
-    message.nextClientSequence !== undefined &&
-      (obj.nextClientSequence = (
-        message.nextClientSequence || Long.UZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const baseGenesisMetadata: object = {};
@@ -252,8 +256,12 @@ export const GenesisMetadata = {
     message: GenesisMetadata,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    writer.uint32(18).bytes(message.value);
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(18).bytes(message.value);
+    }
     return writer;
   },
 
@@ -289,6 +297,19 @@ export const GenesisMetadata = {
     return message;
   },
 
+  toJSON(message: GenesisMetadata): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<GenesisMetadata>): GenesisMetadata {
     const message = { ...baseGenesisMetadata } as GenesisMetadata;
     if (object.key !== undefined && object.key !== null) {
@@ -303,19 +324,6 @@ export const GenesisMetadata = {
     }
     return message;
   },
-
-  toJSON(message: GenesisMetadata): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseIdentifiedGenesisMetadata: object = { clientId: '' };
@@ -325,7 +333,9 @@ export const IdentifiedGenesisMetadata = {
     message: IdentifiedGenesisMetadata,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     for (const v of message.clientMetadata) {
       GenesisMetadata.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -379,6 +389,19 @@ export const IdentifiedGenesisMetadata = {
     return message;
   },
 
+  toJSON(message: IdentifiedGenesisMetadata): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    if (message.clientMetadata) {
+      obj.clientMetadata = message.clientMetadata.map((e) =>
+        e ? GenesisMetadata.toJSON(e) : undefined
+      );
+    } else {
+      obj.clientMetadata = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<IdentifiedGenesisMetadata>
   ): IdentifiedGenesisMetadata {
@@ -398,19 +421,6 @@ export const IdentifiedGenesisMetadata = {
     }
     return message;
   },
-
-  toJSON(message: IdentifiedGenesisMetadata): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    if (message.clientMetadata) {
-      obj.clientMetadata = message.clientMetadata.map((e) =>
-        e ? GenesisMetadata.toJSON(e) : undefined
-      );
-    } else {
-      obj.clientMetadata = [];
-    }
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -420,7 +430,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/client/v1/query.ts
+++ b/src/codec/ibc/core/client/v1/query.ts
@@ -128,7 +128,9 @@ export const QueryClientStateRequest = {
     message: QueryClientStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     return writer;
   },
 
@@ -167,6 +169,12 @@ export const QueryClientStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryClientStateRequest): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientStateRequest>
   ): QueryClientStateRequest {
@@ -180,12 +188,6 @@ export const QueryClientStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientStateRequest): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    return obj;
-  },
 };
 
 const baseQueryClientStateResponse: object = {};
@@ -195,17 +197,13 @@ export const QueryClientStateResponse = {
     message: QueryClientStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -260,6 +258,23 @@ export const QueryClientStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryClientStateResponse): unknown {
+    const obj: any = {};
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientStateResponse>
   ): QueryClientStateResponse {
@@ -283,23 +298,6 @@ export const QueryClientStateResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientStateResponse): unknown {
-    const obj: any = {};
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryClientStatesRequest: object = {};
@@ -309,7 +307,7 @@ export const QueryClientStatesRequest = {
     message: QueryClientStatesRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -350,6 +348,15 @@ export const QueryClientStatesRequest = {
     return message;
   },
 
+  toJSON(message: QueryClientStatesRequest): unknown {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientStatesRequest>
   ): QueryClientStatesRequest {
@@ -363,15 +370,6 @@ export const QueryClientStatesRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientStatesRequest): unknown {
-    const obj: any = {};
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryClientStatesResponse: object = {};
@@ -384,7 +382,7 @@ export const QueryClientStatesResponse = {
     for (const v of message.clientStates) {
       IdentifiedClientState.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
@@ -440,6 +438,22 @@ export const QueryClientStatesResponse = {
     return message;
   },
 
+  toJSON(message: QueryClientStatesResponse): unknown {
+    const obj: any = {};
+    if (message.clientStates) {
+      obj.clientStates = message.clientStates.map((e) =>
+        e ? IdentifiedClientState.toJSON(e) : undefined
+      );
+    } else {
+      obj.clientStates = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientStatesResponse>
   ): QueryClientStatesResponse {
@@ -459,22 +473,6 @@ export const QueryClientStatesResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientStatesResponse): unknown {
-    const obj: any = {};
-    if (message.clientStates) {
-      obj.clientStates = message.clientStates.map((e) =>
-        e ? IdentifiedClientState.toJSON(e) : undefined
-      );
-    } else {
-      obj.clientStates = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConsensusStateRequest: object = {
@@ -489,10 +487,18 @@ export const QueryConsensusStateRequest = {
     message: QueryConsensusStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    writer.uint32(16).uint64(message.revisionNumber);
-    writer.uint32(24).uint64(message.revisionHeight);
-    writer.uint32(32).bool(message.latestHeight);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (!message.revisionNumber.isZero()) {
+      writer.uint32(16).uint64(message.revisionNumber);
+    }
+    if (!message.revisionHeight.isZero()) {
+      writer.uint32(24).uint64(message.revisionHeight);
+    }
+    if (message.latestHeight === true) {
+      writer.uint32(32).bool(message.latestHeight);
+    }
     return writer;
   },
 
@@ -555,6 +561,18 @@ export const QueryConsensusStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryConsensusStateRequest): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.revisionNumber !== undefined &&
+      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
+    message.revisionHeight !== undefined &&
+      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
+    message.latestHeight !== undefined &&
+      (obj.latestHeight = message.latestHeight);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConsensusStateRequest>
   ): QueryConsensusStateRequest {
@@ -583,18 +601,6 @@ export const QueryConsensusStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConsensusStateRequest): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.revisionNumber !== undefined &&
-      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
-    message.revisionHeight !== undefined &&
-      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
-    message.latestHeight !== undefined &&
-      (obj.latestHeight = message.latestHeight);
-    return obj;
-  },
 };
 
 const baseQueryConsensusStateResponse: object = {};
@@ -604,17 +610,13 @@ export const QueryConsensusStateResponse = {
     message: QueryConsensusStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -669,6 +671,23 @@ export const QueryConsensusStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryConsensusStateResponse): unknown {
+    const obj: any = {};
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConsensusStateResponse>
   ): QueryConsensusStateResponse {
@@ -692,23 +711,6 @@ export const QueryConsensusStateResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryConsensusStateResponse): unknown {
-    const obj: any = {};
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConsensusStatesRequest: object = { clientId: '' };
@@ -718,8 +720,10 @@ export const QueryConsensusStatesRequest = {
     message: QueryConsensusStatesRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -768,6 +772,16 @@ export const QueryConsensusStatesRequest = {
     return message;
   },
 
+  toJSON(message: QueryConsensusStatesRequest): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConsensusStatesRequest>
   ): QueryConsensusStatesRequest {
@@ -786,16 +800,6 @@ export const QueryConsensusStatesRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConsensusStatesRequest): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConsensusStatesResponse: object = {};
@@ -808,7 +812,7 @@ export const QueryConsensusStatesResponse = {
     for (const v of message.consensusStates) {
       ConsensusStateWithHeight.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
@@ -867,6 +871,22 @@ export const QueryConsensusStatesResponse = {
     return message;
   },
 
+  toJSON(message: QueryConsensusStatesResponse): unknown {
+    const obj: any = {};
+    if (message.consensusStates) {
+      obj.consensusStates = message.consensusStates.map((e) =>
+        e ? ConsensusStateWithHeight.toJSON(e) : undefined
+      );
+    } else {
+      obj.consensusStates = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConsensusStatesResponse>
   ): QueryConsensusStatesResponse {
@@ -888,22 +908,6 @@ export const QueryConsensusStatesResponse = {
       message.pagination = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryConsensusStatesResponse): unknown {
-    const obj: any = {};
-    if (message.consensusStates) {
-      obj.consensusStates = message.consensusStates.map((e) =>
-        e ? ConsensusStateWithHeight.toJSON(e) : undefined
-      );
-    } else {
-      obj.consensusStates = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    return obj;
   },
 };
 
@@ -944,6 +948,11 @@ export const QueryClientParamsRequest = {
     return message;
   },
 
+  toJSON(_: QueryClientParamsRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<QueryClientParamsRequest>
   ): QueryClientParamsRequest {
@@ -951,11 +960,6 @@ export const QueryClientParamsRequest = {
       ...baseQueryClientParamsRequest,
     } as QueryClientParamsRequest;
     return message;
-  },
-
-  toJSON(_: QueryClientParamsRequest): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -966,7 +970,7 @@ export const QueryClientParamsResponse = {
     message: QueryClientParamsResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.params !== undefined && message.params !== undefined) {
+    if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -1007,6 +1011,13 @@ export const QueryClientParamsResponse = {
     return message;
   },
 
+  toJSON(message: QueryClientParamsResponse): unknown {
+    const obj: any = {};
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientParamsResponse>
   ): QueryClientParamsResponse {
@@ -1019,13 +1030,6 @@ export const QueryClientParamsResponse = {
       message.params = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryClientParamsResponse): unknown {
-    const obj: any = {};
-    message.params !== undefined &&
-      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
-    return obj;
   },
 };
 
@@ -1150,7 +1154,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/client/v1/tx.ts
+++ b/src/codec/ibc/core/client/v1/tx.ts
@@ -79,19 +79,15 @@ export const MsgCreateClient = {
     message: MsgCreateClient,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(10).fork()).ldelim();
     }
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(26).string(message.signer);
+    }
     return writer;
   },
 
@@ -139,6 +135,20 @@ export const MsgCreateClient = {
     return message;
   },
 
+  toJSON(message: MsgCreateClient): unknown {
+    const obj: any = {};
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgCreateClient>): MsgCreateClient {
     const message = { ...baseMsgCreateClient } as MsgCreateClient;
     if (object.clientState !== undefined && object.clientState !== null) {
@@ -157,20 +167,6 @@ export const MsgCreateClient = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgCreateClient): unknown {
-    const obj: any = {};
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -211,6 +207,11 @@ export const MsgCreateClientResponse = {
     return message;
   },
 
+  toJSON(_: MsgCreateClientResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgCreateClientResponse>
   ): MsgCreateClientResponse {
@@ -218,11 +219,6 @@ export const MsgCreateClientResponse = {
       ...baseMsgCreateClientResponse,
     } as MsgCreateClientResponse;
     return message;
-  },
-
-  toJSON(_: MsgCreateClientResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -233,11 +229,15 @@ export const MsgUpdateClient = {
     message: MsgUpdateClient,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (message.header !== undefined && message.header !== undefined) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.header !== undefined) {
       Any.encode(message.header, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(26).string(message.signer);
+    }
     return writer;
   },
 
@@ -285,6 +285,15 @@ export const MsgUpdateClient = {
     return message;
   },
 
+  toJSON(message: MsgUpdateClient): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.header !== undefined &&
+      (obj.header = message.header ? Any.toJSON(message.header) : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgUpdateClient>): MsgUpdateClient {
     const message = { ...baseMsgUpdateClient } as MsgUpdateClient;
     if (object.clientId !== undefined && object.clientId !== null) {
@@ -303,15 +312,6 @@ export const MsgUpdateClient = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgUpdateClient): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.header !== undefined &&
-      (obj.header = message.header ? Any.toJSON(message.header) : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -352,6 +352,11 @@ export const MsgUpdateClientResponse = {
     return message;
   },
 
+  toJSON(_: MsgUpdateClientResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgUpdateClientResponse>
   ): MsgUpdateClientResponse {
@@ -359,11 +364,6 @@ export const MsgUpdateClientResponse = {
       ...baseMsgUpdateClientResponse,
     } as MsgUpdateClientResponse;
     return message;
-  },
-
-  toJSON(_: MsgUpdateClientResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -374,22 +374,24 @@ export const MsgUpgradeClient = {
     message: MsgUpgradeClient,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(18).fork()).ldelim();
     }
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).bytes(message.proofUpgradeClient);
-    writer.uint32(42).bytes(message.proofUpgradeConsensusState);
-    writer.uint32(50).string(message.signer);
+    if (message.proofUpgradeClient.length !== 0) {
+      writer.uint32(34).bytes(message.proofUpgradeClient);
+    }
+    if (message.proofUpgradeConsensusState.length !== 0) {
+      writer.uint32(42).bytes(message.proofUpgradeConsensusState);
+    }
+    if (message.signer !== '') {
+      writer.uint32(50).string(message.signer);
+    }
     return writer;
   },
 
@@ -465,6 +467,33 @@ export const MsgUpgradeClient = {
     return message;
   },
 
+  toJSON(message: MsgUpgradeClient): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    message.proofUpgradeClient !== undefined &&
+      (obj.proofUpgradeClient = base64FromBytes(
+        message.proofUpgradeClient !== undefined
+          ? message.proofUpgradeClient
+          : new Uint8Array()
+      ));
+    message.proofUpgradeConsensusState !== undefined &&
+      (obj.proofUpgradeConsensusState = base64FromBytes(
+        message.proofUpgradeConsensusState !== undefined
+          ? message.proofUpgradeConsensusState
+          : new Uint8Array()
+      ));
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgUpgradeClient>): MsgUpgradeClient {
     const message = { ...baseMsgUpgradeClient } as MsgUpgradeClient;
     if (object.clientId !== undefined && object.clientId !== null) {
@@ -505,33 +534,6 @@ export const MsgUpgradeClient = {
     }
     return message;
   },
-
-  toJSON(message: MsgUpgradeClient): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    message.proofUpgradeClient !== undefined &&
-      (obj.proofUpgradeClient = base64FromBytes(
-        message.proofUpgradeClient !== undefined
-          ? message.proofUpgradeClient
-          : new Uint8Array()
-      ));
-    message.proofUpgradeConsensusState !== undefined &&
-      (obj.proofUpgradeConsensusState = base64FromBytes(
-        message.proofUpgradeConsensusState !== undefined
-          ? message.proofUpgradeConsensusState
-          : new Uint8Array()
-      ));
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgUpgradeClientResponse: object = {};
@@ -571,6 +573,11 @@ export const MsgUpgradeClientResponse = {
     return message;
   },
 
+  toJSON(_: MsgUpgradeClientResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgUpgradeClientResponse>
   ): MsgUpgradeClientResponse {
@@ -578,11 +585,6 @@ export const MsgUpgradeClientResponse = {
       ...baseMsgUpgradeClientResponse,
     } as MsgUpgradeClientResponse;
     return message;
-  },
-
-  toJSON(_: MsgUpgradeClientResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -593,14 +595,15 @@ export const MsgSubmitMisbehaviour = {
     message: MsgSubmitMisbehaviour,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (
-      message.misbehaviour !== undefined &&
-      message.misbehaviour !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.misbehaviour !== undefined) {
       Any.encode(message.misbehaviour, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(26).string(message.signer);
+    }
     return writer;
   },
 
@@ -651,6 +654,17 @@ export const MsgSubmitMisbehaviour = {
     return message;
   },
 
+  toJSON(message: MsgSubmitMisbehaviour): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.misbehaviour !== undefined &&
+      (obj.misbehaviour = message.misbehaviour
+        ? Any.toJSON(message.misbehaviour)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<MsgSubmitMisbehaviour>
   ): MsgSubmitMisbehaviour {
@@ -671,17 +685,6 @@ export const MsgSubmitMisbehaviour = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgSubmitMisbehaviour): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.misbehaviour !== undefined &&
-      (obj.misbehaviour = message.misbehaviour
-        ? Any.toJSON(message.misbehaviour)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -722,6 +725,11 @@ export const MsgSubmitMisbehaviourResponse = {
     return message;
   },
 
+  toJSON(_: MsgSubmitMisbehaviourResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgSubmitMisbehaviourResponse>
   ): MsgSubmitMisbehaviourResponse {
@@ -729,11 +737,6 @@ export const MsgSubmitMisbehaviourResponse = {
       ...baseMsgSubmitMisbehaviourResponse,
     } as MsgSubmitMisbehaviourResponse;
     return message;
-  },
-
-  toJSON(_: MsgSubmitMisbehaviourResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -822,7 +825,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/commitment/v1/commitment.ts
+++ b/src/codec/ibc/core/commitment/v1/commitment.ts
@@ -49,7 +49,9 @@ export const MerkleRoot = {
     message: MerkleRoot,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.hash);
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
     return writer;
   },
 
@@ -79,6 +81,15 @@ export const MerkleRoot = {
     return message;
   },
 
+  toJSON(message: MerkleRoot): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(
+        message.hash !== undefined ? message.hash : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MerkleRoot>): MerkleRoot {
     const message = { ...baseMerkleRoot } as MerkleRoot;
     if (object.hash !== undefined && object.hash !== null) {
@@ -87,15 +98,6 @@ export const MerkleRoot = {
       message.hash = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: MerkleRoot): unknown {
-    const obj: any = {};
-    message.hash !== undefined &&
-      (obj.hash = base64FromBytes(
-        message.hash !== undefined ? message.hash : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -106,7 +108,9 @@ export const MerklePrefix = {
     message: MerklePrefix,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.keyPrefix);
+    if (message.keyPrefix.length !== 0) {
+      writer.uint32(10).bytes(message.keyPrefix);
+    }
     return writer;
   },
 
@@ -136,6 +140,15 @@ export const MerklePrefix = {
     return message;
   },
 
+  toJSON(message: MerklePrefix): unknown {
+    const obj: any = {};
+    message.keyPrefix !== undefined &&
+      (obj.keyPrefix = base64FromBytes(
+        message.keyPrefix !== undefined ? message.keyPrefix : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MerklePrefix>): MerklePrefix {
     const message = { ...baseMerklePrefix } as MerklePrefix;
     if (object.keyPrefix !== undefined && object.keyPrefix !== null) {
@@ -144,15 +157,6 @@ export const MerklePrefix = {
       message.keyPrefix = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: MerklePrefix): unknown {
-    const obj: any = {};
-    message.keyPrefix !== undefined &&
-      (obj.keyPrefix = base64FromBytes(
-        message.keyPrefix !== undefined ? message.keyPrefix : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -199,6 +203,16 @@ export const MerklePath = {
     return message;
   },
 
+  toJSON(message: MerklePath): unknown {
+    const obj: any = {};
+    if (message.keyPath) {
+      obj.keyPath = message.keyPath.map((e) => e);
+    } else {
+      obj.keyPath = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MerklePath>): MerklePath {
     const message = { ...baseMerklePath } as MerklePath;
     message.keyPath = [];
@@ -208,16 +222,6 @@ export const MerklePath = {
       }
     }
     return message;
-  },
-
-  toJSON(message: MerklePath): unknown {
-    const obj: any = {};
-    if (message.keyPath) {
-      obj.keyPath = message.keyPath.map((e) => e);
-    } else {
-      obj.keyPath = [];
-    }
-    return obj;
   },
 };
 
@@ -264,17 +268,6 @@ export const MerkleProof = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<MerkleProof>): MerkleProof {
-    const message = { ...baseMerkleProof } as MerkleProof;
-    message.proofs = [];
-    if (object.proofs !== undefined && object.proofs !== null) {
-      for (const e of object.proofs) {
-        message.proofs.push(CommitmentProof.fromPartial(e));
-      }
-    }
-    return message;
-  },
-
   toJSON(message: MerkleProof): unknown {
     const obj: any = {};
     if (message.proofs) {
@@ -286,6 +279,17 @@ export const MerkleProof = {
     }
     return obj;
   },
+
+  fromPartial(object: DeepPartial<MerkleProof>): MerkleProof {
+    const message = { ...baseMerkleProof } as MerkleProof;
+    message.proofs = [];
+    if (object.proofs !== undefined && object.proofs !== null) {
+      for (const e of object.proofs) {
+        message.proofs.push(CommitmentProof.fromPartial(e));
+      }
+    }
+    return message;
+  },
 };
 
 declare var self: any | undefined;
@@ -295,7 +299,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/connection/v1/connection.ts
+++ b/src/codec/ibc/core/connection/v1/connection.ts
@@ -159,21 +159,24 @@ export const ConnectionEnd = {
     message: ConnectionEnd,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     for (const v of message.versions) {
       Version.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).int32(message.state);
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.state !== 0) {
+      writer.uint32(24).int32(message.state);
+    }
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(34).fork()
       ).ldelim();
     }
-    writer.uint32(40).uint64(message.delayPeriod);
+    if (!message.delayPeriod.isZero()) {
+      writer.uint32(40).uint64(message.delayPeriod);
+    }
     return writer;
   },
 
@@ -239,6 +242,26 @@ export const ConnectionEnd = {
     return message;
   },
 
+  toJSON(message: ConnectionEnd): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    if (message.versions) {
+      obj.versions = message.versions.map((e) =>
+        e ? Version.toJSON(e) : undefined
+      );
+    } else {
+      obj.versions = [];
+    }
+    message.state !== undefined && (obj.state = stateToJSON(message.state));
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    message.delayPeriod !== undefined &&
+      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConnectionEnd>): ConnectionEnd {
     const message = { ...baseConnectionEnd } as ConnectionEnd;
     message.versions = [];
@@ -269,26 +292,6 @@ export const ConnectionEnd = {
     }
     return message;
   },
-
-  toJSON(message: ConnectionEnd): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    if (message.versions) {
-      obj.versions = message.versions.map((e) =>
-        e ? Version.toJSON(e) : undefined
-      );
-    } else {
-      obj.versions = [];
-    }
-    message.state !== undefined && (obj.state = stateToJSON(message.state));
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    message.delayPeriod !== undefined &&
-      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseIdentifiedConnection: object = {
@@ -303,22 +306,27 @@ export const IdentifiedConnection = {
     message: IdentifiedConnection,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.id);
-    writer.uint32(18).string(message.clientId);
+    if (message.id !== '') {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.clientId !== '') {
+      writer.uint32(18).string(message.clientId);
+    }
     for (const v of message.versions) {
       Version.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(32).int32(message.state);
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.state !== 0) {
+      writer.uint32(32).int32(message.state);
+    }
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(42).fork()
       ).ldelim();
     }
-    writer.uint32(48).uint64(message.delayPeriod);
+    if (!message.delayPeriod.isZero()) {
+      writer.uint32(48).uint64(message.delayPeriod);
+    }
     return writer;
   },
 
@@ -395,6 +403,27 @@ export const IdentifiedConnection = {
     return message;
   },
 
+  toJSON(message: IdentifiedConnection): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    if (message.versions) {
+      obj.versions = message.versions.map((e) =>
+        e ? Version.toJSON(e) : undefined
+      );
+    } else {
+      obj.versions = [];
+    }
+    message.state !== undefined && (obj.state = stateToJSON(message.state));
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    message.delayPeriod !== undefined &&
+      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<IdentifiedConnection>): IdentifiedConnection {
     const message = { ...baseIdentifiedConnection } as IdentifiedConnection;
     message.versions = [];
@@ -430,27 +459,6 @@ export const IdentifiedConnection = {
     }
     return message;
   },
-
-  toJSON(message: IdentifiedConnection): unknown {
-    const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    if (message.versions) {
-      obj.versions = message.versions.map((e) =>
-        e ? Version.toJSON(e) : undefined
-      );
-    } else {
-      obj.versions = [];
-    }
-    message.state !== undefined && (obj.state = stateToJSON(message.state));
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    message.delayPeriod !== undefined &&
-      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseCounterparty: object = { clientId: '', connectionId: '' };
@@ -460,9 +468,13 @@ export const Counterparty = {
     message: Counterparty,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    writer.uint32(18).string(message.connectionId);
-    if (message.prefix !== undefined && message.prefix !== undefined) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.connectionId !== '') {
+      writer.uint32(18).string(message.connectionId);
+    }
+    if (message.prefix !== undefined) {
       MerklePrefix.encode(message.prefix, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -512,6 +524,18 @@ export const Counterparty = {
     return message;
   },
 
+  toJSON(message: Counterparty): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    message.prefix !== undefined &&
+      (obj.prefix = message.prefix
+        ? MerklePrefix.toJSON(message.prefix)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Counterparty>): Counterparty {
     const message = { ...baseCounterparty } as Counterparty;
     if (object.clientId !== undefined && object.clientId !== null) {
@@ -530,18 +554,6 @@ export const Counterparty = {
       message.prefix = undefined;
     }
     return message;
-  },
-
-  toJSON(message: Counterparty): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    message.prefix !== undefined &&
-      (obj.prefix = message.prefix
-        ? MerklePrefix.toJSON(message.prefix)
-        : undefined);
-    return obj;
   },
 };
 
@@ -588,6 +600,16 @@ export const ClientPaths = {
     return message;
   },
 
+  toJSON(message: ClientPaths): unknown {
+    const obj: any = {};
+    if (message.paths) {
+      obj.paths = message.paths.map((e) => e);
+    } else {
+      obj.paths = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientPaths>): ClientPaths {
     const message = { ...baseClientPaths } as ClientPaths;
     message.paths = [];
@@ -598,16 +620,6 @@ export const ClientPaths = {
     }
     return message;
   },
-
-  toJSON(message: ClientPaths): unknown {
-    const obj: any = {};
-    if (message.paths) {
-      obj.paths = message.paths.map((e) => e);
-    } else {
-      obj.paths = [];
-    }
-    return obj;
-  },
 };
 
 const baseConnectionPaths: object = { clientId: '', paths: '' };
@@ -617,7 +629,9 @@ export const ConnectionPaths = {
     message: ConnectionPaths,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     for (const v of message.paths) {
       writer.uint32(18).string(v!);
     }
@@ -662,6 +676,17 @@ export const ConnectionPaths = {
     return message;
   },
 
+  toJSON(message: ConnectionPaths): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    if (message.paths) {
+      obj.paths = message.paths.map((e) => e);
+    } else {
+      obj.paths = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConnectionPaths>): ConnectionPaths {
     const message = { ...baseConnectionPaths } as ConnectionPaths;
     message.paths = [];
@@ -677,17 +702,6 @@ export const ConnectionPaths = {
     }
     return message;
   },
-
-  toJSON(message: ConnectionPaths): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    if (message.paths) {
-      obj.paths = message.paths.map((e) => e);
-    } else {
-      obj.paths = [];
-    }
-    return obj;
-  },
 };
 
 const baseVersion: object = { identifier: '', features: '' };
@@ -697,7 +711,9 @@ export const Version = {
     message: Version,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.identifier);
+    if (message.identifier !== '') {
+      writer.uint32(10).string(message.identifier);
+    }
     for (const v of message.features) {
       writer.uint32(18).string(v!);
     }
@@ -742,6 +758,17 @@ export const Version = {
     return message;
   },
 
+  toJSON(message: Version): unknown {
+    const obj: any = {};
+    message.identifier !== undefined && (obj.identifier = message.identifier);
+    if (message.features) {
+      obj.features = message.features.map((e) => e);
+    } else {
+      obj.features = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Version>): Version {
     const message = { ...baseVersion } as Version;
     message.features = [];
@@ -756,17 +783,6 @@ export const Version = {
       }
     }
     return message;
-  },
-
-  toJSON(message: Version): unknown {
-    const obj: any = {};
-    message.identifier !== undefined && (obj.identifier = message.identifier);
-    if (message.features) {
-      obj.features = message.features.map((e) => e);
-    } else {
-      obj.features = [];
-    }
-    return obj;
   },
 };
 

--- a/src/codec/ibc/core/connection/v1/genesis.ts
+++ b/src/codec/ibc/core/connection/v1/genesis.ts
@@ -29,7 +29,9 @@ export const GenesisState = {
     for (const v of message.clientConnectionPaths) {
       ConnectionPaths.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).uint64(message.nextConnectionSequence);
+    if (!message.nextConnectionSequence.isZero()) {
+      writer.uint32(24).uint64(message.nextConnectionSequence);
+    }
     return writer;
   },
 
@@ -93,6 +95,29 @@ export const GenesisState = {
     return message;
   },
 
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    if (message.connections) {
+      obj.connections = message.connections.map((e) =>
+        e ? IdentifiedConnection.toJSON(e) : undefined
+      );
+    } else {
+      obj.connections = [];
+    }
+    if (message.clientConnectionPaths) {
+      obj.clientConnectionPaths = message.clientConnectionPaths.map((e) =>
+        e ? ConnectionPaths.toJSON(e) : undefined
+      );
+    } else {
+      obj.clientConnectionPaths = [];
+    }
+    message.nextConnectionSequence !== undefined &&
+      (obj.nextConnectionSequence = (
+        message.nextConnectionSequence || Long.UZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<GenesisState>): GenesisState {
     const message = { ...baseGenesisState } as GenesisState;
     message.connections = [];
@@ -119,29 +144,6 @@ export const GenesisState = {
       message.nextConnectionSequence = Long.UZERO;
     }
     return message;
-  },
-
-  toJSON(message: GenesisState): unknown {
-    const obj: any = {};
-    if (message.connections) {
-      obj.connections = message.connections.map((e) =>
-        e ? IdentifiedConnection.toJSON(e) : undefined
-      );
-    } else {
-      obj.connections = [];
-    }
-    if (message.clientConnectionPaths) {
-      obj.clientConnectionPaths = message.clientConnectionPaths.map((e) =>
-        e ? ConnectionPaths.toJSON(e) : undefined
-      );
-    } else {
-      obj.clientConnectionPaths = [];
-    }
-    message.nextConnectionSequence !== undefined &&
-      (obj.nextConnectionSequence = (
-        message.nextConnectionSequence || Long.UZERO
-      ).toString());
-    return obj;
   },
 };
 

--- a/src/codec/ibc/core/connection/v1/query.ts
+++ b/src/codec/ibc/core/connection/v1/query.ts
@@ -138,7 +138,9 @@ export const QueryConnectionRequest = {
     message: QueryConnectionRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connectionId);
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId);
+    }
     return writer;
   },
 
@@ -173,6 +175,13 @@ export const QueryConnectionRequest = {
     return message;
   },
 
+  toJSON(message: QueryConnectionRequest): unknown {
+    const obj: any = {};
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionRequest>
   ): QueryConnectionRequest {
@@ -184,13 +193,6 @@ export const QueryConnectionRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionRequest): unknown {
-    const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    return obj;
-  },
 };
 
 const baseQueryConnectionResponse: object = {};
@@ -200,17 +202,16 @@ export const QueryConnectionResponse = {
     message: QueryConnectionResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.connection !== undefined && message.connection !== undefined) {
+    if (message.connection !== undefined) {
       ConnectionEnd.encode(
         message.connection,
         writer.uint32(10).fork()
       ).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -265,6 +266,23 @@ export const QueryConnectionResponse = {
     return message;
   },
 
+  toJSON(message: QueryConnectionResponse): unknown {
+    const obj: any = {};
+    message.connection !== undefined &&
+      (obj.connection = message.connection
+        ? ConnectionEnd.toJSON(message.connection)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionResponse>
   ): QueryConnectionResponse {
@@ -288,23 +306,6 @@ export const QueryConnectionResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionResponse): unknown {
-    const obj: any = {};
-    message.connection !== undefined &&
-      (obj.connection = message.connection
-        ? ConnectionEnd.toJSON(message.connection)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionsRequest: object = {};
@@ -314,7 +315,7 @@ export const QueryConnectionsRequest = {
     message: QueryConnectionsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
     }
     return writer;
@@ -355,6 +356,15 @@ export const QueryConnectionsRequest = {
     return message;
   },
 
+  toJSON(message: QueryConnectionsRequest): unknown {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionsRequest>
   ): QueryConnectionsRequest {
@@ -368,15 +378,6 @@ export const QueryConnectionsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionsRequest): unknown {
-    const obj: any = {};
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionsResponse: object = {};
@@ -389,13 +390,13 @@ export const QueryConnectionsResponse = {
     for (const v of message.connections) {
       IdentifiedConnection.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.pagination !== undefined && message.pagination !== undefined) {
+    if (message.pagination !== undefined) {
       PageResponse.encode(
         message.pagination,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -456,6 +457,24 @@ export const QueryConnectionsResponse = {
     return message;
   },
 
+  toJSON(message: QueryConnectionsResponse): unknown {
+    const obj: any = {};
+    if (message.connections) {
+      obj.connections = message.connections.map((e) =>
+        e ? IdentifiedConnection.toJSON(e) : undefined
+      );
+    } else {
+      obj.connections = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionsResponse>
   ): QueryConnectionsResponse {
@@ -480,24 +499,6 @@ export const QueryConnectionsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionsResponse): unknown {
-    const obj: any = {};
-    if (message.connections) {
-      obj.connections = message.connections.map((e) =>
-        e ? IdentifiedConnection.toJSON(e) : undefined
-      );
-    } else {
-      obj.connections = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
-  },
 };
 
 const baseQueryClientConnectionsRequest: object = { clientId: '' };
@@ -507,7 +508,9 @@ export const QueryClientConnectionsRequest = {
     message: QueryClientConnectionsRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
     return writer;
   },
 
@@ -546,6 +549,12 @@ export const QueryClientConnectionsRequest = {
     return message;
   },
 
+  toJSON(message: QueryClientConnectionsRequest): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientConnectionsRequest>
   ): QueryClientConnectionsRequest {
@@ -559,12 +568,6 @@ export const QueryClientConnectionsRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientConnectionsRequest): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    return obj;
-  },
 };
 
 const baseQueryClientConnectionsResponse: object = { connectionPaths: '' };
@@ -577,11 +580,10 @@ export const QueryClientConnectionsResponse = {
     for (const v of message.connectionPaths) {
       writer.uint32(10).string(v!);
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -641,6 +643,24 @@ export const QueryClientConnectionsResponse = {
     return message;
   },
 
+  toJSON(message: QueryClientConnectionsResponse): unknown {
+    const obj: any = {};
+    if (message.connectionPaths) {
+      obj.connectionPaths = message.connectionPaths.map((e) => e);
+    } else {
+      obj.connectionPaths = [];
+    }
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryClientConnectionsResponse>
   ): QueryClientConnectionsResponse {
@@ -668,24 +688,6 @@ export const QueryClientConnectionsResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryClientConnectionsResponse): unknown {
-    const obj: any = {};
-    if (message.connectionPaths) {
-      obj.connectionPaths = message.connectionPaths.map((e) => e);
-    } else {
-      obj.connectionPaths = [];
-    }
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionClientStateRequest: object = { connectionId: '' };
@@ -695,7 +697,9 @@ export const QueryConnectionClientStateRequest = {
     message: QueryConnectionClientStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connectionId);
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId);
+    }
     return writer;
   },
 
@@ -734,6 +738,13 @@ export const QueryConnectionClientStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryConnectionClientStateRequest): unknown {
+    const obj: any = {};
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionClientStateRequest>
   ): QueryConnectionClientStateRequest {
@@ -747,13 +758,6 @@ export const QueryConnectionClientStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionClientStateRequest): unknown {
-    const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    return obj;
-  },
 };
 
 const baseQueryConnectionClientStateResponse: object = {};
@@ -763,20 +767,16 @@ export const QueryConnectionClientStateResponse = {
     message: QueryConnectionClientStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.identifiedClientState !== undefined &&
-      message.identifiedClientState !== undefined
-    ) {
+    if (message.identifiedClientState !== undefined) {
       IdentifiedClientState.encode(
         message.identifiedClientState,
         writer.uint32(10).fork()
       ).ldelim();
     }
-    writer.uint32(18).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proof.length !== 0) {
+      writer.uint32(18).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -839,6 +839,23 @@ export const QueryConnectionClientStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryConnectionClientStateResponse): unknown {
+    const obj: any = {};
+    message.identifiedClientState !== undefined &&
+      (obj.identifiedClientState = message.identifiedClientState
+        ? IdentifiedClientState.toJSON(message.identifiedClientState)
+        : undefined);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionClientStateResponse>
   ): QueryConnectionClientStateResponse {
@@ -867,23 +884,6 @@ export const QueryConnectionClientStateResponse = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionClientStateResponse): unknown {
-    const obj: any = {};
-    message.identifiedClientState !== undefined &&
-      (obj.identifiedClientState = message.identifiedClientState
-        ? IdentifiedClientState.toJSON(message.identifiedClientState)
-        : undefined);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseQueryConnectionConsensusStateRequest: object = {
@@ -897,9 +897,15 @@ export const QueryConnectionConsensusStateRequest = {
     message: QueryConnectionConsensusStateRequest,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connectionId);
-    writer.uint32(16).uint64(message.revisionNumber);
-    writer.uint32(24).uint64(message.revisionHeight);
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId);
+    }
+    if (!message.revisionNumber.isZero()) {
+      writer.uint32(16).uint64(message.revisionNumber);
+    }
+    if (!message.revisionHeight.isZero()) {
+      writer.uint32(24).uint64(message.revisionHeight);
+    }
     return writer;
   },
 
@@ -954,6 +960,17 @@ export const QueryConnectionConsensusStateRequest = {
     return message;
   },
 
+  toJSON(message: QueryConnectionConsensusStateRequest): unknown {
+    const obj: any = {};
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    message.revisionNumber !== undefined &&
+      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
+    message.revisionHeight !== undefined &&
+      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionConsensusStateRequest>
   ): QueryConnectionConsensusStateRequest {
@@ -977,17 +994,6 @@ export const QueryConnectionConsensusStateRequest = {
     }
     return message;
   },
-
-  toJSON(message: QueryConnectionConsensusStateRequest): unknown {
-    const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    message.revisionNumber !== undefined &&
-      (obj.revisionNumber = (message.revisionNumber || Long.UZERO).toString());
-    message.revisionHeight !== undefined &&
-      (obj.revisionHeight = (message.revisionHeight || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseQueryConnectionConsensusStateResponse: object = { clientId: '' };
@@ -997,18 +1003,16 @@ export const QueryConnectionConsensusStateResponse = {
     message: QueryConnectionConsensusStateResponse,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.clientId);
-    writer.uint32(26).bytes(message.proof);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(18).string(message.clientId);
+    }
+    if (message.proof.length !== 0) {
+      writer.uint32(26).bytes(message.proof);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -1071,6 +1075,24 @@ export const QueryConnectionConsensusStateResponse = {
     return message;
   },
 
+  toJSON(message: QueryConnectionConsensusStateResponse): unknown {
+    const obj: any = {};
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.proof !== undefined &&
+      (obj.proof = base64FromBytes(
+        message.proof !== undefined ? message.proof : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<QueryConnectionConsensusStateResponse>
   ): QueryConnectionConsensusStateResponse {
@@ -1098,24 +1120,6 @@ export const QueryConnectionConsensusStateResponse = {
       message.proofHeight = undefined;
     }
     return message;
-  },
-
-  toJSON(message: QueryConnectionConsensusStateResponse): unknown {
-    const obj: any = {};
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.proof !== undefined &&
-      (obj.proof = base64FromBytes(
-        message.proof !== undefined ? message.proof : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    return obj;
   },
 };
 
@@ -1241,7 +1245,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/core/connection/v1/tx.ts
+++ b/src/codec/ibc/core/connection/v1/tx.ts
@@ -109,21 +109,24 @@ export const MsgConnectionOpenInit = {
     message: MsgConnectionOpenInit,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.version !== undefined && message.version !== undefined) {
+    if (message.version !== undefined) {
       Version.encode(message.version, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(32).uint64(message.delayPeriod);
-    writer.uint32(42).string(message.signer);
+    if (!message.delayPeriod.isZero()) {
+      writer.uint32(32).uint64(message.delayPeriod);
+    }
+    if (message.signer !== '') {
+      writer.uint32(42).string(message.signer);
+    }
     return writer;
   },
 
@@ -190,6 +193,23 @@ export const MsgConnectionOpenInit = {
     return message;
   },
 
+  toJSON(message: MsgConnectionOpenInit): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    message.version !== undefined &&
+      (obj.version = message.version
+        ? Version.toJSON(message.version)
+        : undefined);
+    message.delayPeriod !== undefined &&
+      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<MsgConnectionOpenInit>
   ): MsgConnectionOpenInit {
@@ -220,23 +240,6 @@ export const MsgConnectionOpenInit = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgConnectionOpenInit): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    message.version !== undefined &&
-      (obj.version = message.version
-        ? Version.toJSON(message.version)
-        : undefined);
-    message.delayPeriod !== undefined &&
-      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -277,6 +280,11 @@ export const MsgConnectionOpenInitResponse = {
     return message;
   },
 
+  toJSON(_: MsgConnectionOpenInitResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgConnectionOpenInitResponse>
   ): MsgConnectionOpenInitResponse {
@@ -284,11 +292,6 @@ export const MsgConnectionOpenInitResponse = {
       ...baseMsgConnectionOpenInitResponse,
     } as MsgConnectionOpenInitResponse;
     return message;
-  },
-
-  toJSON(_: MsgConnectionOpenInitResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -304,43 +307,45 @@ export const MsgConnectionOpenTry = {
     message: MsgConnectionOpenTry,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    writer.uint32(18).string(message.previousConnectionId);
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.previousConnectionId !== '') {
+      writer.uint32(18).string(message.previousConnectionId);
+    }
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(26).fork()).ldelim();
     }
-    if (
-      message.counterparty !== undefined &&
-      message.counterparty !== undefined
-    ) {
+    if (message.counterparty !== undefined) {
       Counterparty.encode(
         message.counterparty,
         writer.uint32(34).fork()
       ).ldelim();
     }
-    writer.uint32(40).uint64(message.delayPeriod);
+    if (!message.delayPeriod.isZero()) {
+      writer.uint32(40).uint64(message.delayPeriod);
+    }
     for (const v of message.counterpartyVersions) {
       Version.encode(v!, writer.uint32(50).fork()).ldelim();
     }
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(58).fork()).ldelim();
     }
-    writer.uint32(66).bytes(message.proofInit);
-    writer.uint32(74).bytes(message.proofClient);
-    writer.uint32(82).bytes(message.proofConsensus);
-    if (
-      message.consensusHeight !== undefined &&
-      message.consensusHeight !== undefined
-    ) {
+    if (message.proofInit.length !== 0) {
+      writer.uint32(66).bytes(message.proofInit);
+    }
+    if (message.proofClient.length !== 0) {
+      writer.uint32(74).bytes(message.proofClient);
+    }
+    if (message.proofConsensus.length !== 0) {
+      writer.uint32(82).bytes(message.proofConsensus);
+    }
+    if (message.consensusHeight !== undefined) {
       Height.encode(message.consensusHeight, writer.uint32(90).fork()).ldelim();
     }
-    writer.uint32(98).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(98).string(message.signer);
+    }
     return writer;
   },
 
@@ -470,6 +475,56 @@ export const MsgConnectionOpenTry = {
     return message;
   },
 
+  toJSON(message: MsgConnectionOpenTry): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.previousConnectionId !== undefined &&
+      (obj.previousConnectionId = message.previousConnectionId);
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    message.counterparty !== undefined &&
+      (obj.counterparty = message.counterparty
+        ? Counterparty.toJSON(message.counterparty)
+        : undefined);
+    message.delayPeriod !== undefined &&
+      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
+    if (message.counterpartyVersions) {
+      obj.counterpartyVersions = message.counterpartyVersions.map((e) =>
+        e ? Version.toJSON(e) : undefined
+      );
+    } else {
+      obj.counterpartyVersions = [];
+    }
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.proofInit !== undefined &&
+      (obj.proofInit = base64FromBytes(
+        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
+      ));
+    message.proofClient !== undefined &&
+      (obj.proofClient = base64FromBytes(
+        message.proofClient !== undefined
+          ? message.proofClient
+          : new Uint8Array()
+      ));
+    message.proofConsensus !== undefined &&
+      (obj.proofConsensus = base64FromBytes(
+        message.proofConsensus !== undefined
+          ? message.proofConsensus
+          : new Uint8Array()
+      ));
+    message.consensusHeight !== undefined &&
+      (obj.consensusHeight = message.consensusHeight
+        ? Height.toJSON(message.consensusHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgConnectionOpenTry>): MsgConnectionOpenTry {
     const message = { ...baseMsgConnectionOpenTry } as MsgConnectionOpenTry;
     message.counterpartyVersions = [];
@@ -544,56 +599,6 @@ export const MsgConnectionOpenTry = {
     }
     return message;
   },
-
-  toJSON(message: MsgConnectionOpenTry): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.previousConnectionId !== undefined &&
-      (obj.previousConnectionId = message.previousConnectionId);
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    message.counterparty !== undefined &&
-      (obj.counterparty = message.counterparty
-        ? Counterparty.toJSON(message.counterparty)
-        : undefined);
-    message.delayPeriod !== undefined &&
-      (obj.delayPeriod = (message.delayPeriod || Long.UZERO).toString());
-    if (message.counterpartyVersions) {
-      obj.counterpartyVersions = message.counterpartyVersions.map((e) =>
-        e ? Version.toJSON(e) : undefined
-      );
-    } else {
-      obj.counterpartyVersions = [];
-    }
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.proofInit !== undefined &&
-      (obj.proofInit = base64FromBytes(
-        message.proofInit !== undefined ? message.proofInit : new Uint8Array()
-      ));
-    message.proofClient !== undefined &&
-      (obj.proofClient = base64FromBytes(
-        message.proofClient !== undefined
-          ? message.proofClient
-          : new Uint8Array()
-      ));
-    message.proofConsensus !== undefined &&
-      (obj.proofConsensus = base64FromBytes(
-        message.proofConsensus !== undefined
-          ? message.proofConsensus
-          : new Uint8Array()
-      ));
-    message.consensusHeight !== undefined &&
-      (obj.consensusHeight = message.consensusHeight
-        ? Height.toJSON(message.consensusHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgConnectionOpenTryResponse: object = {};
@@ -633,6 +638,11 @@ export const MsgConnectionOpenTryResponse = {
     return message;
   },
 
+  toJSON(_: MsgConnectionOpenTryResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgConnectionOpenTryResponse>
   ): MsgConnectionOpenTryResponse {
@@ -640,11 +650,6 @@ export const MsgConnectionOpenTryResponse = {
       ...baseMsgConnectionOpenTryResponse,
     } as MsgConnectionOpenTryResponse;
     return message;
-  },
-
-  toJSON(_: MsgConnectionOpenTryResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -659,33 +664,36 @@ export const MsgConnectionOpenAck = {
     message: MsgConnectionOpenAck,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connectionId);
-    writer.uint32(18).string(message.counterpartyConnectionId);
-    if (message.version !== undefined && message.version !== undefined) {
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId);
+    }
+    if (message.counterpartyConnectionId !== '') {
+      writer.uint32(18).string(message.counterpartyConnectionId);
+    }
+    if (message.version !== undefined) {
       Version.encode(message.version, writer.uint32(26).fork()).ldelim();
     }
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(34).fork()).ldelim();
     }
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(42).fork()).ldelim();
     }
-    writer.uint32(50).bytes(message.proofTry);
-    writer.uint32(58).bytes(message.proofClient);
-    writer.uint32(66).bytes(message.proofConsensus);
-    if (
-      message.consensusHeight !== undefined &&
-      message.consensusHeight !== undefined
-    ) {
+    if (message.proofTry.length !== 0) {
+      writer.uint32(50).bytes(message.proofTry);
+    }
+    if (message.proofClient.length !== 0) {
+      writer.uint32(58).bytes(message.proofClient);
+    }
+    if (message.proofConsensus.length !== 0) {
+      writer.uint32(66).bytes(message.proofConsensus);
+    }
+    if (message.consensusHeight !== undefined) {
       Height.encode(message.consensusHeight, writer.uint32(74).fork()).ldelim();
     }
-    writer.uint32(82).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(82).string(message.signer);
+    }
     return writer;
   },
 
@@ -794,6 +802,48 @@ export const MsgConnectionOpenAck = {
     return message;
   },
 
+  toJSON(message: MsgConnectionOpenAck): unknown {
+    const obj: any = {};
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    message.counterpartyConnectionId !== undefined &&
+      (obj.counterpartyConnectionId = message.counterpartyConnectionId);
+    message.version !== undefined &&
+      (obj.version = message.version
+        ? Version.toJSON(message.version)
+        : undefined);
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.proofTry !== undefined &&
+      (obj.proofTry = base64FromBytes(
+        message.proofTry !== undefined ? message.proofTry : new Uint8Array()
+      ));
+    message.proofClient !== undefined &&
+      (obj.proofClient = base64FromBytes(
+        message.proofClient !== undefined
+          ? message.proofClient
+          : new Uint8Array()
+      ));
+    message.proofConsensus !== undefined &&
+      (obj.proofConsensus = base64FromBytes(
+        message.proofConsensus !== undefined
+          ? message.proofConsensus
+          : new Uint8Array()
+      ));
+    message.consensusHeight !== undefined &&
+      (obj.consensusHeight = message.consensusHeight
+        ? Height.toJSON(message.consensusHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<MsgConnectionOpenAck>): MsgConnectionOpenAck {
     const message = { ...baseMsgConnectionOpenAck } as MsgConnectionOpenAck;
     if (object.connectionId !== undefined && object.connectionId !== null) {
@@ -854,48 +904,6 @@ export const MsgConnectionOpenAck = {
     }
     return message;
   },
-
-  toJSON(message: MsgConnectionOpenAck): unknown {
-    const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    message.counterpartyConnectionId !== undefined &&
-      (obj.counterpartyConnectionId = message.counterpartyConnectionId);
-    message.version !== undefined &&
-      (obj.version = message.version
-        ? Version.toJSON(message.version)
-        : undefined);
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.proofTry !== undefined &&
-      (obj.proofTry = base64FromBytes(
-        message.proofTry !== undefined ? message.proofTry : new Uint8Array()
-      ));
-    message.proofClient !== undefined &&
-      (obj.proofClient = base64FromBytes(
-        message.proofClient !== undefined
-          ? message.proofClient
-          : new Uint8Array()
-      ));
-    message.proofConsensus !== undefined &&
-      (obj.proofConsensus = base64FromBytes(
-        message.proofConsensus !== undefined
-          ? message.proofConsensus
-          : new Uint8Array()
-      ));
-    message.consensusHeight !== undefined &&
-      (obj.consensusHeight = message.consensusHeight
-        ? Height.toJSON(message.consensusHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
-  },
 };
 
 const baseMsgConnectionOpenAckResponse: object = {};
@@ -935,6 +943,11 @@ export const MsgConnectionOpenAckResponse = {
     return message;
   },
 
+  toJSON(_: MsgConnectionOpenAckResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgConnectionOpenAckResponse>
   ): MsgConnectionOpenAckResponse {
@@ -942,11 +955,6 @@ export const MsgConnectionOpenAckResponse = {
       ...baseMsgConnectionOpenAckResponse,
     } as MsgConnectionOpenAckResponse;
     return message;
-  },
-
-  toJSON(_: MsgConnectionOpenAckResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -957,15 +965,18 @@ export const MsgConnectionOpenConfirm = {
     message: MsgConnectionOpenConfirm,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.connectionId);
-    writer.uint32(18).bytes(message.proofAck);
-    if (
-      message.proofHeight !== undefined &&
-      message.proofHeight !== undefined
-    ) {
+    if (message.connectionId !== '') {
+      writer.uint32(10).string(message.connectionId);
+    }
+    if (message.proofAck.length !== 0) {
+      writer.uint32(18).bytes(message.proofAck);
+    }
+    if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).string(message.signer);
+    if (message.signer !== '') {
+      writer.uint32(34).string(message.signer);
+    }
     return writer;
   },
 
@@ -1026,6 +1037,22 @@ export const MsgConnectionOpenConfirm = {
     return message;
   },
 
+  toJSON(message: MsgConnectionOpenConfirm): unknown {
+    const obj: any = {};
+    message.connectionId !== undefined &&
+      (obj.connectionId = message.connectionId);
+    message.proofAck !== undefined &&
+      (obj.proofAck = base64FromBytes(
+        message.proofAck !== undefined ? message.proofAck : new Uint8Array()
+      ));
+    message.proofHeight !== undefined &&
+      (obj.proofHeight = message.proofHeight
+        ? Height.toJSON(message.proofHeight)
+        : undefined);
+    message.signer !== undefined && (obj.signer = message.signer);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<MsgConnectionOpenConfirm>
   ): MsgConnectionOpenConfirm {
@@ -1053,22 +1080,6 @@ export const MsgConnectionOpenConfirm = {
       message.signer = '';
     }
     return message;
-  },
-
-  toJSON(message: MsgConnectionOpenConfirm): unknown {
-    const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
-    message.proofAck !== undefined &&
-      (obj.proofAck = base64FromBytes(
-        message.proofAck !== undefined ? message.proofAck : new Uint8Array()
-      ));
-    message.proofHeight !== undefined &&
-      (obj.proofHeight = message.proofHeight
-        ? Height.toJSON(message.proofHeight)
-        : undefined);
-    message.signer !== undefined && (obj.signer = message.signer);
-    return obj;
   },
 };
 
@@ -1109,6 +1120,11 @@ export const MsgConnectionOpenConfirmResponse = {
     return message;
   },
 
+  toJSON(_: MsgConnectionOpenConfirmResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
   fromPartial(
     _: DeepPartial<MsgConnectionOpenConfirmResponse>
   ): MsgConnectionOpenConfirmResponse {
@@ -1116,11 +1132,6 @@ export const MsgConnectionOpenConfirmResponse = {
       ...baseMsgConnectionOpenConfirmResponse,
     } as MsgConnectionOpenConfirmResponse;
     return message;
-  },
-
-  toJSON(_: MsgConnectionOpenConfirmResponse): unknown {
-    const obj: any = {};
-    return obj;
   },
 };
 
@@ -1221,7 +1232,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/lightclients/localhost/v1/localhost.ts
+++ b/src/codec/ibc/lightclients/localhost/v1/localhost.ts
@@ -23,8 +23,10 @@ export const ClientState = {
     message: ClientState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.chainId);
-    if (message.height !== undefined && message.height !== undefined) {
+    if (message.chainId !== '') {
+      writer.uint32(10).string(message.chainId);
+    }
+    if (message.height !== undefined) {
       Height.encode(message.height, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -66,6 +68,14 @@ export const ClientState = {
     return message;
   },
 
+  toJSON(message: ClientState): unknown {
+    const obj: any = {};
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.height !== undefined &&
+      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientState>): ClientState {
     const message = { ...baseClientState } as ClientState;
     if (object.chainId !== undefined && object.chainId !== null) {
@@ -79,14 +89,6 @@ export const ClientState = {
       message.height = undefined;
     }
     return message;
-  },
-
-  toJSON(message: ClientState): unknown {
-    const obj: any = {};
-    message.chainId !== undefined && (obj.chainId = message.chainId);
-    message.height !== undefined &&
-      (obj.height = message.height ? Height.toJSON(message.height) : undefined);
-    return obj;
   },
 };
 

--- a/src/codec/ibc/lightclients/solomachine/v1/solomachine.ts
+++ b/src/codec/ibc/lightclients/solomachine/v1/solomachine.ts
@@ -272,18 +272,21 @@ export const ClientState = {
     message: ClientState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.sequence);
-    writer.uint32(16).uint64(message.frozenSequence);
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (!message.sequence.isZero()) {
+      writer.uint32(8).uint64(message.sequence);
+    }
+    if (!message.frozenSequence.isZero()) {
+      writer.uint32(16).uint64(message.frozenSequence);
+    }
+    if (message.consensusState !== undefined) {
       ConsensusState.encode(
         message.consensusState,
         writer.uint32(26).fork()
       ).ldelim();
     }
-    writer.uint32(32).bool(message.allowUpdateAfterProposal);
+    if (message.allowUpdateAfterProposal === true) {
+      writer.uint32(32).bool(message.allowUpdateAfterProposal);
+    }
     return writer;
   },
 
@@ -347,6 +350,21 @@ export const ClientState = {
     return message;
   },
 
+  toJSON(message: ClientState): unknown {
+    const obj: any = {};
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.frozenSequence !== undefined &&
+      (obj.frozenSequence = (message.frozenSequence || Long.UZERO).toString());
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? ConsensusState.toJSON(message.consensusState)
+        : undefined);
+    message.allowUpdateAfterProposal !== undefined &&
+      (obj.allowUpdateAfterProposal = message.allowUpdateAfterProposal);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientState>): ClientState {
     const message = { ...baseClientState } as ClientState;
     if (object.sequence !== undefined && object.sequence !== null) {
@@ -376,21 +394,6 @@ export const ClientState = {
     }
     return message;
   },
-
-  toJSON(message: ClientState): unknown {
-    const obj: any = {};
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.frozenSequence !== undefined &&
-      (obj.frozenSequence = (message.frozenSequence || Long.UZERO).toString());
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? ConsensusState.toJSON(message.consensusState)
-        : undefined);
-    message.allowUpdateAfterProposal !== undefined &&
-      (obj.allowUpdateAfterProposal = message.allowUpdateAfterProposal);
-    return obj;
-  },
 };
 
 const baseConsensusState: object = { diversifier: '', timestamp: Long.UZERO };
@@ -400,11 +403,15 @@ export const ConsensusState = {
     message: ConsensusState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.publicKey !== undefined && message.publicKey !== undefined) {
+    if (message.publicKey !== undefined) {
       Any.encode(message.publicKey, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.diversifier);
-    writer.uint32(24).uint64(message.timestamp);
+    if (message.diversifier !== '') {
+      writer.uint32(18).string(message.diversifier);
+    }
+    if (!message.timestamp.isZero()) {
+      writer.uint32(24).uint64(message.timestamp);
+    }
     return writer;
   },
 
@@ -452,6 +459,19 @@ export const ConsensusState = {
     return message;
   },
 
+  toJSON(message: ConsensusState): unknown {
+    const obj: any = {};
+    message.publicKey !== undefined &&
+      (obj.publicKey = message.publicKey
+        ? Any.toJSON(message.publicKey)
+        : undefined);
+    message.diversifier !== undefined &&
+      (obj.diversifier = message.diversifier);
+    message.timestamp !== undefined &&
+      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConsensusState>): ConsensusState {
     const message = { ...baseConsensusState } as ConsensusState;
     if (object.publicKey !== undefined && object.publicKey !== null) {
@@ -471,19 +491,6 @@ export const ConsensusState = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusState): unknown {
-    const obj: any = {};
-    message.publicKey !== undefined &&
-      (obj.publicKey = message.publicKey
-        ? Any.toJSON(message.publicKey)
-        : undefined);
-    message.diversifier !== undefined &&
-      (obj.diversifier = message.diversifier);
-    message.timestamp !== undefined &&
-      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseHeader: object = {
@@ -497,16 +504,21 @@ export const Header = {
     message: Header,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.sequence);
-    writer.uint32(16).uint64(message.timestamp);
-    writer.uint32(26).bytes(message.signature);
-    if (
-      message.newPublicKey !== undefined &&
-      message.newPublicKey !== undefined
-    ) {
+    if (!message.sequence.isZero()) {
+      writer.uint32(8).uint64(message.sequence);
+    }
+    if (!message.timestamp.isZero()) {
+      writer.uint32(16).uint64(message.timestamp);
+    }
+    if (message.signature.length !== 0) {
+      writer.uint32(26).bytes(message.signature);
+    }
+    if (message.newPublicKey !== undefined) {
       Any.encode(message.newPublicKey, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(42).string(message.newDiversifier);
+    if (message.newDiversifier !== '') {
+      writer.uint32(42).string(message.newDiversifier);
+    }
     return writer;
   },
 
@@ -568,6 +580,25 @@ export const Header = {
     return message;
   },
 
+  toJSON(message: Header): unknown {
+    const obj: any = {};
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.timestamp !== undefined &&
+      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(
+        message.signature !== undefined ? message.signature : new Uint8Array()
+      ));
+    message.newPublicKey !== undefined &&
+      (obj.newPublicKey = message.newPublicKey
+        ? Any.toJSON(message.newPublicKey)
+        : undefined);
+    message.newDiversifier !== undefined &&
+      (obj.newDiversifier = message.newDiversifier);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Header>): Header {
     const message = { ...baseHeader } as Header;
     if (object.sequence !== undefined && object.sequence !== null) {
@@ -597,25 +628,6 @@ export const Header = {
     }
     return message;
   },
-
-  toJSON(message: Header): unknown {
-    const obj: any = {};
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.timestamp !== undefined &&
-      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(
-        message.signature !== undefined ? message.signature : new Uint8Array()
-      ));
-    message.newPublicKey !== undefined &&
-      (obj.newPublicKey = message.newPublicKey
-        ? Any.toJSON(message.newPublicKey)
-        : undefined);
-    message.newDiversifier !== undefined &&
-      (obj.newDiversifier = message.newDiversifier);
-    return obj;
-  },
 };
 
 const baseMisbehaviour: object = { clientId: '', sequence: Long.UZERO };
@@ -625,21 +637,19 @@ export const Misbehaviour = {
     message: Misbehaviour,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    writer.uint32(16).uint64(message.sequence);
-    if (
-      message.signatureOne !== undefined &&
-      message.signatureOne !== undefined
-    ) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (!message.sequence.isZero()) {
+      writer.uint32(16).uint64(message.sequence);
+    }
+    if (message.signatureOne !== undefined) {
       SignatureAndData.encode(
         message.signatureOne,
         writer.uint32(26).fork()
       ).ldelim();
     }
-    if (
-      message.signatureTwo !== undefined &&
-      message.signatureTwo !== undefined
-    ) {
+    if (message.signatureTwo !== undefined) {
       SignatureAndData.encode(
         message.signatureTwo,
         writer.uint32(34).fork()
@@ -706,6 +716,22 @@ export const Misbehaviour = {
     return message;
   },
 
+  toJSON(message: Misbehaviour): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.signatureOne !== undefined &&
+      (obj.signatureOne = message.signatureOne
+        ? SignatureAndData.toJSON(message.signatureOne)
+        : undefined);
+    message.signatureTwo !== undefined &&
+      (obj.signatureTwo = message.signatureTwo
+        ? SignatureAndData.toJSON(message.signatureTwo)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Misbehaviour>): Misbehaviour {
     const message = { ...baseMisbehaviour } as Misbehaviour;
     if (object.clientId !== undefined && object.clientId !== null) {
@@ -730,22 +756,6 @@ export const Misbehaviour = {
     }
     return message;
   },
-
-  toJSON(message: Misbehaviour): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.signatureOne !== undefined &&
-      (obj.signatureOne = message.signatureOne
-        ? SignatureAndData.toJSON(message.signatureOne)
-        : undefined);
-    message.signatureTwo !== undefined &&
-      (obj.signatureTwo = message.signatureTwo
-        ? SignatureAndData.toJSON(message.signatureTwo)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseSignatureAndData: object = { dataType: 0, timestamp: Long.UZERO };
@@ -755,10 +765,18 @@ export const SignatureAndData = {
     message: SignatureAndData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.signature);
-    writer.uint32(16).int32(message.dataType);
-    writer.uint32(26).bytes(message.data);
-    writer.uint32(32).uint64(message.timestamp);
+    if (message.signature.length !== 0) {
+      writer.uint32(10).bytes(message.signature);
+    }
+    if (message.dataType !== 0) {
+      writer.uint32(16).int32(message.dataType);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(26).bytes(message.data);
+    }
+    if (!message.timestamp.isZero()) {
+      writer.uint32(32).uint64(message.timestamp);
+    }
     return writer;
   },
 
@@ -810,6 +828,23 @@ export const SignatureAndData = {
     return message;
   },
 
+  toJSON(message: SignatureAndData): unknown {
+    const obj: any = {};
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(
+        message.signature !== undefined ? message.signature : new Uint8Array()
+      ));
+    message.dataType !== undefined &&
+      (obj.dataType = dataTypeToJSON(message.dataType));
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.timestamp !== undefined &&
+      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<SignatureAndData>): SignatureAndData {
     const message = { ...baseSignatureAndData } as SignatureAndData;
     if (object.signature !== undefined && object.signature !== null) {
@@ -834,23 +869,6 @@ export const SignatureAndData = {
     }
     return message;
   },
-
-  toJSON(message: SignatureAndData): unknown {
-    const obj: any = {};
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(
-        message.signature !== undefined ? message.signature : new Uint8Array()
-      ));
-    message.dataType !== undefined &&
-      (obj.dataType = dataTypeToJSON(message.dataType));
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.timestamp !== undefined &&
-      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseTimestampedSignatureData: object = { timestamp: Long.UZERO };
@@ -860,8 +878,12 @@ export const TimestampedSignatureData = {
     message: TimestampedSignatureData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.signatureData);
-    writer.uint32(16).uint64(message.timestamp);
+    if (message.signatureData.length !== 0) {
+      writer.uint32(10).bytes(message.signatureData);
+    }
+    if (!message.timestamp.isZero()) {
+      writer.uint32(16).uint64(message.timestamp);
+    }
     return writer;
   },
 
@@ -906,6 +928,19 @@ export const TimestampedSignatureData = {
     return message;
   },
 
+  toJSON(message: TimestampedSignatureData): unknown {
+    const obj: any = {};
+    message.signatureData !== undefined &&
+      (obj.signatureData = base64FromBytes(
+        message.signatureData !== undefined
+          ? message.signatureData
+          : new Uint8Array()
+      ));
+    message.timestamp !== undefined &&
+      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<TimestampedSignatureData>
   ): TimestampedSignatureData {
@@ -924,19 +959,6 @@ export const TimestampedSignatureData = {
     }
     return message;
   },
-
-  toJSON(message: TimestampedSignatureData): unknown {
-    const obj: any = {};
-    message.signatureData !== undefined &&
-      (obj.signatureData = base64FromBytes(
-        message.signatureData !== undefined
-          ? message.signatureData
-          : new Uint8Array()
-      ));
-    message.timestamp !== undefined &&
-      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseSignBytes: object = {
@@ -951,11 +973,21 @@ export const SignBytes = {
     message: SignBytes,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.sequence);
-    writer.uint32(16).uint64(message.timestamp);
-    writer.uint32(26).string(message.diversifier);
-    writer.uint32(32).int32(message.dataType);
-    writer.uint32(42).bytes(message.data);
+    if (!message.sequence.isZero()) {
+      writer.uint32(8).uint64(message.sequence);
+    }
+    if (!message.timestamp.isZero()) {
+      writer.uint32(16).uint64(message.timestamp);
+    }
+    if (message.diversifier !== '') {
+      writer.uint32(26).string(message.diversifier);
+    }
+    if (message.dataType !== 0) {
+      writer.uint32(32).int32(message.dataType);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(42).bytes(message.data);
+    }
     return writer;
   },
 
@@ -1017,6 +1049,23 @@ export const SignBytes = {
     return message;
   },
 
+  toJSON(message: SignBytes): unknown {
+    const obj: any = {};
+    message.sequence !== undefined &&
+      (obj.sequence = (message.sequence || Long.UZERO).toString());
+    message.timestamp !== undefined &&
+      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
+    message.diversifier !== undefined &&
+      (obj.diversifier = message.diversifier);
+    message.dataType !== undefined &&
+      (obj.dataType = dataTypeToJSON(message.dataType));
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<SignBytes>): SignBytes {
     const message = { ...baseSignBytes } as SignBytes;
     if (object.sequence !== undefined && object.sequence !== null) {
@@ -1046,23 +1095,6 @@ export const SignBytes = {
     }
     return message;
   },
-
-  toJSON(message: SignBytes): unknown {
-    const obj: any = {};
-    message.sequence !== undefined &&
-      (obj.sequence = (message.sequence || Long.UZERO).toString());
-    message.timestamp !== undefined &&
-      (obj.timestamp = (message.timestamp || Long.UZERO).toString());
-    message.diversifier !== undefined &&
-      (obj.diversifier = message.diversifier);
-    message.dataType !== undefined &&
-      (obj.dataType = dataTypeToJSON(message.dataType));
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseHeaderData: object = { newDiversifier: '' };
@@ -1072,10 +1104,12 @@ export const HeaderData = {
     message: HeaderData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.newPubKey !== undefined && message.newPubKey !== undefined) {
+    if (message.newPubKey !== undefined) {
       Any.encode(message.newPubKey, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.newDiversifier);
+    if (message.newDiversifier !== '') {
+      writer.uint32(18).string(message.newDiversifier);
+    }
     return writer;
   },
 
@@ -1115,6 +1149,17 @@ export const HeaderData = {
     return message;
   },
 
+  toJSON(message: HeaderData): unknown {
+    const obj: any = {};
+    message.newPubKey !== undefined &&
+      (obj.newPubKey = message.newPubKey
+        ? Any.toJSON(message.newPubKey)
+        : undefined);
+    message.newDiversifier !== undefined &&
+      (obj.newDiversifier = message.newDiversifier);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<HeaderData>): HeaderData {
     const message = { ...baseHeaderData } as HeaderData;
     if (object.newPubKey !== undefined && object.newPubKey !== null) {
@@ -1129,17 +1174,6 @@ export const HeaderData = {
     }
     return message;
   },
-
-  toJSON(message: HeaderData): unknown {
-    const obj: any = {};
-    message.newPubKey !== undefined &&
-      (obj.newPubKey = message.newPubKey
-        ? Any.toJSON(message.newPubKey)
-        : undefined);
-    message.newDiversifier !== undefined &&
-      (obj.newDiversifier = message.newDiversifier);
-    return obj;
-  },
 };
 
 const baseClientStateData: object = {};
@@ -1149,11 +1183,10 @@ export const ClientStateData = {
     message: ClientStateData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    if (
-      message.clientState !== undefined &&
-      message.clientState !== undefined
-    ) {
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.clientState !== undefined) {
       Any.encode(message.clientState, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1193,6 +1226,19 @@ export const ClientStateData = {
     return message;
   },
 
+  toJSON(message: ClientStateData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.clientState !== undefined &&
+      (obj.clientState = message.clientState
+        ? Any.toJSON(message.clientState)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientStateData>): ClientStateData {
     const message = { ...baseClientStateData } as ClientStateData;
     if (object.path !== undefined && object.path !== null) {
@@ -1207,19 +1253,6 @@ export const ClientStateData = {
     }
     return message;
   },
-
-  toJSON(message: ClientStateData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.clientState !== undefined &&
-      (obj.clientState = message.clientState
-        ? Any.toJSON(message.clientState)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseConsensusStateData: object = {};
@@ -1229,11 +1262,10 @@ export const ConsensusStateData = {
     message: ConsensusStateData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    if (
-      message.consensusState !== undefined &&
-      message.consensusState !== undefined
-    ) {
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1273,6 +1305,19 @@ export const ConsensusStateData = {
     return message;
   },
 
+  toJSON(message: ConsensusStateData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.consensusState !== undefined &&
+      (obj.consensusState = message.consensusState
+        ? Any.toJSON(message.consensusState)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConsensusStateData>): ConsensusStateData {
     const message = { ...baseConsensusStateData } as ConsensusStateData;
     if (object.path !== undefined && object.path !== null) {
@@ -1287,19 +1332,6 @@ export const ConsensusStateData = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusStateData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.consensusState !== undefined &&
-      (obj.consensusState = message.consensusState
-        ? Any.toJSON(message.consensusState)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseConnectionStateData: object = {};
@@ -1309,8 +1341,10 @@ export const ConnectionStateData = {
     message: ConnectionStateData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    if (message.connection !== undefined && message.connection !== undefined) {
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.connection !== undefined) {
       ConnectionEnd.encode(
         message.connection,
         writer.uint32(18).fork()
@@ -1353,6 +1387,19 @@ export const ConnectionStateData = {
     return message;
   },
 
+  toJSON(message: ConnectionStateData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.connection !== undefined &&
+      (obj.connection = message.connection
+        ? ConnectionEnd.toJSON(message.connection)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConnectionStateData>): ConnectionStateData {
     const message = { ...baseConnectionStateData } as ConnectionStateData;
     if (object.path !== undefined && object.path !== null) {
@@ -1367,19 +1414,6 @@ export const ConnectionStateData = {
     }
     return message;
   },
-
-  toJSON(message: ConnectionStateData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.connection !== undefined &&
-      (obj.connection = message.connection
-        ? ConnectionEnd.toJSON(message.connection)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseChannelStateData: object = {};
@@ -1389,8 +1423,10 @@ export const ChannelStateData = {
     message: ChannelStateData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    if (message.channel !== undefined && message.channel !== undefined) {
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1430,6 +1466,19 @@ export const ChannelStateData = {
     return message;
   },
 
+  toJSON(message: ChannelStateData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.channel !== undefined &&
+      (obj.channel = message.channel
+        ? Channel.toJSON(message.channel)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ChannelStateData>): ChannelStateData {
     const message = { ...baseChannelStateData } as ChannelStateData;
     if (object.path !== undefined && object.path !== null) {
@@ -1444,19 +1493,6 @@ export const ChannelStateData = {
     }
     return message;
   },
-
-  toJSON(message: ChannelStateData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.channel !== undefined &&
-      (obj.channel = message.channel
-        ? Channel.toJSON(message.channel)
-        : undefined);
-    return obj;
-  },
 };
 
 const basePacketCommitmentData: object = {};
@@ -1466,8 +1502,12 @@ export const PacketCommitmentData = {
     message: PacketCommitmentData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    writer.uint32(18).bytes(message.commitment);
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.commitment.length !== 0) {
+      writer.uint32(18).bytes(message.commitment);
+    }
     return writer;
   },
 
@@ -1506,6 +1546,19 @@ export const PacketCommitmentData = {
     return message;
   },
 
+  toJSON(message: PacketCommitmentData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.commitment !== undefined &&
+      (obj.commitment = base64FromBytes(
+        message.commitment !== undefined ? message.commitment : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PacketCommitmentData>): PacketCommitmentData {
     const message = { ...basePacketCommitmentData } as PacketCommitmentData;
     if (object.path !== undefined && object.path !== null) {
@@ -1520,19 +1573,6 @@ export const PacketCommitmentData = {
     }
     return message;
   },
-
-  toJSON(message: PacketCommitmentData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.commitment !== undefined &&
-      (obj.commitment = base64FromBytes(
-        message.commitment !== undefined ? message.commitment : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const basePacketAcknowledgementData: object = {};
@@ -1542,8 +1582,12 @@ export const PacketAcknowledgementData = {
     message: PacketAcknowledgementData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    writer.uint32(18).bytes(message.acknowledgement);
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (message.acknowledgement.length !== 0) {
+      writer.uint32(18).bytes(message.acknowledgement);
+    }
     return writer;
   },
 
@@ -1589,6 +1633,21 @@ export const PacketAcknowledgementData = {
     return message;
   },
 
+  toJSON(message: PacketAcknowledgementData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.acknowledgement !== undefined &&
+      (obj.acknowledgement = base64FromBytes(
+        message.acknowledgement !== undefined
+          ? message.acknowledgement
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<PacketAcknowledgementData>
   ): PacketAcknowledgementData {
@@ -1610,21 +1669,6 @@ export const PacketAcknowledgementData = {
     }
     return message;
   },
-
-  toJSON(message: PacketAcknowledgementData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.acknowledgement !== undefined &&
-      (obj.acknowledgement = base64FromBytes(
-        message.acknowledgement !== undefined
-          ? message.acknowledgement
-          : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const basePacketReceiptAbsenceData: object = {};
@@ -1634,7 +1678,9 @@ export const PacketReceiptAbsenceData = {
     message: PacketReceiptAbsenceData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
     return writer;
   },
 
@@ -1671,6 +1717,15 @@ export const PacketReceiptAbsenceData = {
     return message;
   },
 
+  toJSON(message: PacketReceiptAbsenceData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<PacketReceiptAbsenceData>
   ): PacketReceiptAbsenceData {
@@ -1684,15 +1739,6 @@ export const PacketReceiptAbsenceData = {
     }
     return message;
   },
-
-  toJSON(message: PacketReceiptAbsenceData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseNextSequenceRecvData: object = { nextSeqRecv: Long.UZERO };
@@ -1702,8 +1748,12 @@ export const NextSequenceRecvData = {
     message: NextSequenceRecvData,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.path);
-    writer.uint32(16).uint64(message.nextSeqRecv);
+    if (message.path.length !== 0) {
+      writer.uint32(10).bytes(message.path);
+    }
+    if (!message.nextSeqRecv.isZero()) {
+      writer.uint32(16).uint64(message.nextSeqRecv);
+    }
     return writer;
   },
 
@@ -1744,6 +1794,17 @@ export const NextSequenceRecvData = {
     return message;
   },
 
+  toJSON(message: NextSequenceRecvData): unknown {
+    const obj: any = {};
+    message.path !== undefined &&
+      (obj.path = base64FromBytes(
+        message.path !== undefined ? message.path : new Uint8Array()
+      ));
+    message.nextSeqRecv !== undefined &&
+      (obj.nextSeqRecv = (message.nextSeqRecv || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<NextSequenceRecvData>): NextSequenceRecvData {
     const message = { ...baseNextSequenceRecvData } as NextSequenceRecvData;
     if (object.path !== undefined && object.path !== null) {
@@ -1758,17 +1819,6 @@ export const NextSequenceRecvData = {
     }
     return message;
   },
-
-  toJSON(message: NextSequenceRecvData): unknown {
-    const obj: any = {};
-    message.path !== undefined &&
-      (obj.path = base64FromBytes(
-        message.path !== undefined ? message.path : new Uint8Array()
-      ));
-    message.nextSeqRecv !== undefined &&
-      (obj.nextSeqRecv = (message.nextSeqRecv || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -1778,7 +1828,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/ibc/lightclients/tendermint/v1/tendermint.ts
+++ b/src/codec/ibc/lightclients/tendermint/v1/tendermint.ts
@@ -114,44 +114,31 @@ export const ClientState = {
     message: ClientState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.chainId);
-    if (message.trustLevel !== undefined && message.trustLevel !== undefined) {
+    if (message.chainId !== '') {
+      writer.uint32(10).string(message.chainId);
+    }
+    if (message.trustLevel !== undefined) {
       Fraction.encode(message.trustLevel, writer.uint32(18).fork()).ldelim();
     }
-    if (
-      message.trustingPeriod !== undefined &&
-      message.trustingPeriod !== undefined
-    ) {
+    if (message.trustingPeriod !== undefined) {
       Duration.encode(
         message.trustingPeriod,
         writer.uint32(26).fork()
       ).ldelim();
     }
-    if (
-      message.unbondingPeriod !== undefined &&
-      message.unbondingPeriod !== undefined
-    ) {
+    if (message.unbondingPeriod !== undefined) {
       Duration.encode(
         message.unbondingPeriod,
         writer.uint32(34).fork()
       ).ldelim();
     }
-    if (
-      message.maxClockDrift !== undefined &&
-      message.maxClockDrift !== undefined
-    ) {
+    if (message.maxClockDrift !== undefined) {
       Duration.encode(message.maxClockDrift, writer.uint32(42).fork()).ldelim();
     }
-    if (
-      message.frozenHeight !== undefined &&
-      message.frozenHeight !== undefined
-    ) {
+    if (message.frozenHeight !== undefined) {
       Height.encode(message.frozenHeight, writer.uint32(50).fork()).ldelim();
     }
-    if (
-      message.latestHeight !== undefined &&
-      message.latestHeight !== undefined
-    ) {
+    if (message.latestHeight !== undefined) {
       Height.encode(message.latestHeight, writer.uint32(58).fork()).ldelim();
     }
     for (const v of message.proofSpecs) {
@@ -160,8 +147,12 @@ export const ClientState = {
     for (const v of message.upgradePath) {
       writer.uint32(74).string(v!);
     }
-    writer.uint32(80).bool(message.allowUpdateAfterExpiry);
-    writer.uint32(88).bool(message.allowUpdateAfterMisbehaviour);
+    if (message.allowUpdateAfterExpiry === true) {
+      writer.uint32(80).bool(message.allowUpdateAfterExpiry);
+    }
+    if (message.allowUpdateAfterMisbehaviour === true) {
+      writer.uint32(88).bool(message.allowUpdateAfterMisbehaviour);
+    }
     return writer;
   },
 
@@ -288,6 +279,52 @@ export const ClientState = {
     return message;
   },
 
+  toJSON(message: ClientState): unknown {
+    const obj: any = {};
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.trustLevel !== undefined &&
+      (obj.trustLevel = message.trustLevel
+        ? Fraction.toJSON(message.trustLevel)
+        : undefined);
+    message.trustingPeriod !== undefined &&
+      (obj.trustingPeriod = message.trustingPeriod
+        ? Duration.toJSON(message.trustingPeriod)
+        : undefined);
+    message.unbondingPeriod !== undefined &&
+      (obj.unbondingPeriod = message.unbondingPeriod
+        ? Duration.toJSON(message.unbondingPeriod)
+        : undefined);
+    message.maxClockDrift !== undefined &&
+      (obj.maxClockDrift = message.maxClockDrift
+        ? Duration.toJSON(message.maxClockDrift)
+        : undefined);
+    message.frozenHeight !== undefined &&
+      (obj.frozenHeight = message.frozenHeight
+        ? Height.toJSON(message.frozenHeight)
+        : undefined);
+    message.latestHeight !== undefined &&
+      (obj.latestHeight = message.latestHeight
+        ? Height.toJSON(message.latestHeight)
+        : undefined);
+    if (message.proofSpecs) {
+      obj.proofSpecs = message.proofSpecs.map((e) =>
+        e ? ProofSpec.toJSON(e) : undefined
+      );
+    } else {
+      obj.proofSpecs = [];
+    }
+    if (message.upgradePath) {
+      obj.upgradePath = message.upgradePath.map((e) => e);
+    } else {
+      obj.upgradePath = [];
+    }
+    message.allowUpdateAfterExpiry !== undefined &&
+      (obj.allowUpdateAfterExpiry = message.allowUpdateAfterExpiry);
+    message.allowUpdateAfterMisbehaviour !== undefined &&
+      (obj.allowUpdateAfterMisbehaviour = message.allowUpdateAfterMisbehaviour);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ClientState>): ClientState {
     const message = { ...baseClientState } as ClientState;
     message.proofSpecs = [];
@@ -359,52 +396,6 @@ export const ClientState = {
     }
     return message;
   },
-
-  toJSON(message: ClientState): unknown {
-    const obj: any = {};
-    message.chainId !== undefined && (obj.chainId = message.chainId);
-    message.trustLevel !== undefined &&
-      (obj.trustLevel = message.trustLevel
-        ? Fraction.toJSON(message.trustLevel)
-        : undefined);
-    message.trustingPeriod !== undefined &&
-      (obj.trustingPeriod = message.trustingPeriod
-        ? Duration.toJSON(message.trustingPeriod)
-        : undefined);
-    message.unbondingPeriod !== undefined &&
-      (obj.unbondingPeriod = message.unbondingPeriod
-        ? Duration.toJSON(message.unbondingPeriod)
-        : undefined);
-    message.maxClockDrift !== undefined &&
-      (obj.maxClockDrift = message.maxClockDrift
-        ? Duration.toJSON(message.maxClockDrift)
-        : undefined);
-    message.frozenHeight !== undefined &&
-      (obj.frozenHeight = message.frozenHeight
-        ? Height.toJSON(message.frozenHeight)
-        : undefined);
-    message.latestHeight !== undefined &&
-      (obj.latestHeight = message.latestHeight
-        ? Height.toJSON(message.latestHeight)
-        : undefined);
-    if (message.proofSpecs) {
-      obj.proofSpecs = message.proofSpecs.map((e) =>
-        e ? ProofSpec.toJSON(e) : undefined
-      );
-    } else {
-      obj.proofSpecs = [];
-    }
-    if (message.upgradePath) {
-      obj.upgradePath = message.upgradePath.map((e) => e);
-    } else {
-      obj.upgradePath = [];
-    }
-    message.allowUpdateAfterExpiry !== undefined &&
-      (obj.allowUpdateAfterExpiry = message.allowUpdateAfterExpiry);
-    message.allowUpdateAfterMisbehaviour !== undefined &&
-      (obj.allowUpdateAfterMisbehaviour = message.allowUpdateAfterMisbehaviour);
-    return obj;
-  },
 };
 
 const baseConsensusState: object = {};
@@ -414,13 +405,15 @@ export const ConsensusState = {
     message: ConsensusState,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.timestamp !== undefined && message.timestamp !== undefined) {
+    if (message.timestamp !== undefined) {
       Timestamp.encode(message.timestamp, writer.uint32(10).fork()).ldelim();
     }
-    if (message.root !== undefined && message.root !== undefined) {
+    if (message.root !== undefined) {
       MerkleRoot.encode(message.root, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).bytes(message.nextValidatorsHash);
+    if (message.nextValidatorsHash.length !== 0) {
+      writer.uint32(26).bytes(message.nextValidatorsHash);
+    }
     return writer;
   },
 
@@ -469,6 +462,24 @@ export const ConsensusState = {
     return message;
   },
 
+  toJSON(message: ConsensusState): unknown {
+    const obj: any = {};
+    message.timestamp !== undefined &&
+      (obj.timestamp =
+        message.timestamp !== undefined
+          ? fromTimestamp(message.timestamp).toISOString()
+          : null);
+    message.root !== undefined &&
+      (obj.root = message.root ? MerkleRoot.toJSON(message.root) : undefined);
+    message.nextValidatorsHash !== undefined &&
+      (obj.nextValidatorsHash = base64FromBytes(
+        message.nextValidatorsHash !== undefined
+          ? message.nextValidatorsHash
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConsensusState>): ConsensusState {
     const message = { ...baseConsensusState } as ConsensusState;
     if (object.timestamp !== undefined && object.timestamp !== null) {
@@ -491,24 +502,6 @@ export const ConsensusState = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusState): unknown {
-    const obj: any = {};
-    message.timestamp !== undefined &&
-      (obj.timestamp =
-        message.timestamp !== undefined
-          ? fromTimestamp(message.timestamp).toISOString()
-          : null);
-    message.root !== undefined &&
-      (obj.root = message.root ? MerkleRoot.toJSON(message.root) : undefined);
-    message.nextValidatorsHash !== undefined &&
-      (obj.nextValidatorsHash = base64FromBytes(
-        message.nextValidatorsHash !== undefined
-          ? message.nextValidatorsHash
-          : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseMisbehaviour: object = { clientId: '' };
@@ -518,11 +511,13 @@ export const Misbehaviour = {
     message: Misbehaviour,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.clientId);
-    if (message.header1 !== undefined && message.header1 !== undefined) {
+    if (message.clientId !== '') {
+      writer.uint32(10).string(message.clientId);
+    }
+    if (message.header1 !== undefined) {
       Header.encode(message.header1, writer.uint32(18).fork()).ldelim();
     }
-    if (message.header2 !== undefined && message.header2 !== undefined) {
+    if (message.header2 !== undefined) {
       Header.encode(message.header2, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -572,6 +567,20 @@ export const Misbehaviour = {
     return message;
   },
 
+  toJSON(message: Misbehaviour): unknown {
+    const obj: any = {};
+    message.clientId !== undefined && (obj.clientId = message.clientId);
+    message.header1 !== undefined &&
+      (obj.header1 = message.header1
+        ? Header.toJSON(message.header1)
+        : undefined);
+    message.header2 !== undefined &&
+      (obj.header2 = message.header2
+        ? Header.toJSON(message.header2)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Misbehaviour>): Misbehaviour {
     const message = { ...baseMisbehaviour } as Misbehaviour;
     if (object.clientId !== undefined && object.clientId !== null) {
@@ -591,20 +600,6 @@ export const Misbehaviour = {
     }
     return message;
   },
-
-  toJSON(message: Misbehaviour): unknown {
-    const obj: any = {};
-    message.clientId !== undefined && (obj.clientId = message.clientId);
-    message.header1 !== undefined &&
-      (obj.header1 = message.header1
-        ? Header.toJSON(message.header1)
-        : undefined);
-    message.header2 !== undefined &&
-      (obj.header2 = message.header2
-        ? Header.toJSON(message.header2)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseHeader: object = {};
@@ -614,34 +609,22 @@ export const Header = {
     message: Header,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.signedHeader !== undefined &&
-      message.signedHeader !== undefined
-    ) {
+    if (message.signedHeader !== undefined) {
       SignedHeader.encode(
         message.signedHeader,
         writer.uint32(10).fork()
       ).ldelim();
     }
-    if (
-      message.validatorSet !== undefined &&
-      message.validatorSet !== undefined
-    ) {
+    if (message.validatorSet !== undefined) {
       ValidatorSet.encode(
         message.validatorSet,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (
-      message.trustedHeight !== undefined &&
-      message.trustedHeight !== undefined
-    ) {
+    if (message.trustedHeight !== undefined) {
       Height.encode(message.trustedHeight, writer.uint32(26).fork()).ldelim();
     }
-    if (
-      message.trustedValidators !== undefined &&
-      message.trustedValidators !== undefined
-    ) {
+    if (message.trustedValidators !== undefined) {
       ValidatorSet.encode(
         message.trustedValidators,
         writer.uint32(34).fork()
@@ -710,6 +693,27 @@ export const Header = {
     return message;
   },
 
+  toJSON(message: Header): unknown {
+    const obj: any = {};
+    message.signedHeader !== undefined &&
+      (obj.signedHeader = message.signedHeader
+        ? SignedHeader.toJSON(message.signedHeader)
+        : undefined);
+    message.validatorSet !== undefined &&
+      (obj.validatorSet = message.validatorSet
+        ? ValidatorSet.toJSON(message.validatorSet)
+        : undefined);
+    message.trustedHeight !== undefined &&
+      (obj.trustedHeight = message.trustedHeight
+        ? Height.toJSON(message.trustedHeight)
+        : undefined);
+    message.trustedValidators !== undefined &&
+      (obj.trustedValidators = message.trustedValidators
+        ? ValidatorSet.toJSON(message.trustedValidators)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Header>): Header {
     const message = { ...baseHeader } as Header;
     if (object.signedHeader !== undefined && object.signedHeader !== null) {
@@ -739,27 +743,6 @@ export const Header = {
     }
     return message;
   },
-
-  toJSON(message: Header): unknown {
-    const obj: any = {};
-    message.signedHeader !== undefined &&
-      (obj.signedHeader = message.signedHeader
-        ? SignedHeader.toJSON(message.signedHeader)
-        : undefined);
-    message.validatorSet !== undefined &&
-      (obj.validatorSet = message.validatorSet
-        ? ValidatorSet.toJSON(message.validatorSet)
-        : undefined);
-    message.trustedHeight !== undefined &&
-      (obj.trustedHeight = message.trustedHeight
-        ? Height.toJSON(message.trustedHeight)
-        : undefined);
-    message.trustedValidators !== undefined &&
-      (obj.trustedValidators = message.trustedValidators
-        ? ValidatorSet.toJSON(message.trustedValidators)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseFraction: object = { numerator: Long.UZERO, denominator: Long.UZERO };
@@ -769,8 +752,12 @@ export const Fraction = {
     message: Fraction,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.numerator);
-    writer.uint32(16).uint64(message.denominator);
+    if (!message.numerator.isZero()) {
+      writer.uint32(8).uint64(message.numerator);
+    }
+    if (!message.denominator.isZero()) {
+      writer.uint32(16).uint64(message.denominator);
+    }
     return writer;
   },
 
@@ -810,6 +797,15 @@ export const Fraction = {
     return message;
   },
 
+  toJSON(message: Fraction): unknown {
+    const obj: any = {};
+    message.numerator !== undefined &&
+      (obj.numerator = (message.numerator || Long.UZERO).toString());
+    message.denominator !== undefined &&
+      (obj.denominator = (message.denominator || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Fraction>): Fraction {
     const message = { ...baseFraction } as Fraction;
     if (object.numerator !== undefined && object.numerator !== null) {
@@ -824,15 +820,6 @@ export const Fraction = {
     }
     return message;
   },
-
-  toJSON(message: Fraction): unknown {
-    const obj: any = {};
-    message.numerator !== undefined &&
-      (obj.numerator = (message.numerator || Long.UZERO).toString());
-    message.denominator !== undefined &&
-      (obj.denominator = (message.denominator || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -842,7 +829,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/abci/types.ts
+++ b/src/codec/tendermint/abci/types.ts
@@ -796,6 +796,67 @@ export const Request = {
     return message;
   },
 
+  toJSON(message: Request): unknown {
+    const obj: any = {};
+    message.echo !== undefined &&
+      (obj.echo = message.echo ? RequestEcho.toJSON(message.echo) : undefined);
+    message.flush !== undefined &&
+      (obj.flush = message.flush
+        ? RequestFlush.toJSON(message.flush)
+        : undefined);
+    message.info !== undefined &&
+      (obj.info = message.info ? RequestInfo.toJSON(message.info) : undefined);
+    message.setOption !== undefined &&
+      (obj.setOption = message.setOption
+        ? RequestSetOption.toJSON(message.setOption)
+        : undefined);
+    message.initChain !== undefined &&
+      (obj.initChain = message.initChain
+        ? RequestInitChain.toJSON(message.initChain)
+        : undefined);
+    message.query !== undefined &&
+      (obj.query = message.query
+        ? RequestQuery.toJSON(message.query)
+        : undefined);
+    message.beginBlock !== undefined &&
+      (obj.beginBlock = message.beginBlock
+        ? RequestBeginBlock.toJSON(message.beginBlock)
+        : undefined);
+    message.checkTx !== undefined &&
+      (obj.checkTx = message.checkTx
+        ? RequestCheckTx.toJSON(message.checkTx)
+        : undefined);
+    message.deliverTx !== undefined &&
+      (obj.deliverTx = message.deliverTx
+        ? RequestDeliverTx.toJSON(message.deliverTx)
+        : undefined);
+    message.endBlock !== undefined &&
+      (obj.endBlock = message.endBlock
+        ? RequestEndBlock.toJSON(message.endBlock)
+        : undefined);
+    message.commit !== undefined &&
+      (obj.commit = message.commit
+        ? RequestCommit.toJSON(message.commit)
+        : undefined);
+    message.listSnapshots !== undefined &&
+      (obj.listSnapshots = message.listSnapshots
+        ? RequestListSnapshots.toJSON(message.listSnapshots)
+        : undefined);
+    message.offerSnapshot !== undefined &&
+      (obj.offerSnapshot = message.offerSnapshot
+        ? RequestOfferSnapshot.toJSON(message.offerSnapshot)
+        : undefined);
+    message.loadSnapshotChunk !== undefined &&
+      (obj.loadSnapshotChunk = message.loadSnapshotChunk
+        ? RequestLoadSnapshotChunk.toJSON(message.loadSnapshotChunk)
+        : undefined);
+    message.applySnapshotChunk !== undefined &&
+      (obj.applySnapshotChunk = message.applySnapshotChunk
+        ? RequestApplySnapshotChunk.toJSON(message.applySnapshotChunk)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Request>): Request {
     const message = { ...baseRequest } as Request;
     if (object.echo !== undefined && object.echo !== null) {
@@ -889,67 +950,6 @@ export const Request = {
     }
     return message;
   },
-
-  toJSON(message: Request): unknown {
-    const obj: any = {};
-    message.echo !== undefined &&
-      (obj.echo = message.echo ? RequestEcho.toJSON(message.echo) : undefined);
-    message.flush !== undefined &&
-      (obj.flush = message.flush
-        ? RequestFlush.toJSON(message.flush)
-        : undefined);
-    message.info !== undefined &&
-      (obj.info = message.info ? RequestInfo.toJSON(message.info) : undefined);
-    message.setOption !== undefined &&
-      (obj.setOption = message.setOption
-        ? RequestSetOption.toJSON(message.setOption)
-        : undefined);
-    message.initChain !== undefined &&
-      (obj.initChain = message.initChain
-        ? RequestInitChain.toJSON(message.initChain)
-        : undefined);
-    message.query !== undefined &&
-      (obj.query = message.query
-        ? RequestQuery.toJSON(message.query)
-        : undefined);
-    message.beginBlock !== undefined &&
-      (obj.beginBlock = message.beginBlock
-        ? RequestBeginBlock.toJSON(message.beginBlock)
-        : undefined);
-    message.checkTx !== undefined &&
-      (obj.checkTx = message.checkTx
-        ? RequestCheckTx.toJSON(message.checkTx)
-        : undefined);
-    message.deliverTx !== undefined &&
-      (obj.deliverTx = message.deliverTx
-        ? RequestDeliverTx.toJSON(message.deliverTx)
-        : undefined);
-    message.endBlock !== undefined &&
-      (obj.endBlock = message.endBlock
-        ? RequestEndBlock.toJSON(message.endBlock)
-        : undefined);
-    message.commit !== undefined &&
-      (obj.commit = message.commit
-        ? RequestCommit.toJSON(message.commit)
-        : undefined);
-    message.listSnapshots !== undefined &&
-      (obj.listSnapshots = message.listSnapshots
-        ? RequestListSnapshots.toJSON(message.listSnapshots)
-        : undefined);
-    message.offerSnapshot !== undefined &&
-      (obj.offerSnapshot = message.offerSnapshot
-        ? RequestOfferSnapshot.toJSON(message.offerSnapshot)
-        : undefined);
-    message.loadSnapshotChunk !== undefined &&
-      (obj.loadSnapshotChunk = message.loadSnapshotChunk
-        ? RequestLoadSnapshotChunk.toJSON(message.loadSnapshotChunk)
-        : undefined);
-    message.applySnapshotChunk !== undefined &&
-      (obj.applySnapshotChunk = message.applySnapshotChunk
-        ? RequestApplySnapshotChunk.toJSON(message.applySnapshotChunk)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseRequestEcho: object = { message: '' };
@@ -959,7 +959,9 @@ export const RequestEcho = {
     message: RequestEcho,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.message);
+    if (message.message !== '') {
+      writer.uint32(10).string(message.message);
+    }
     return writer;
   },
 
@@ -991,6 +993,12 @@ export const RequestEcho = {
     return message;
   },
 
+  toJSON(message: RequestEcho): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestEcho>): RequestEcho {
     const message = { ...baseRequestEcho } as RequestEcho;
     if (object.message !== undefined && object.message !== null) {
@@ -999,12 +1007,6 @@ export const RequestEcho = {
       message.message = '';
     }
     return message;
-  },
-
-  toJSON(message: RequestEcho): unknown {
-    const obj: any = {};
-    message.message !== undefined && (obj.message = message.message);
-    return obj;
   },
 };
 
@@ -1038,14 +1040,14 @@ export const RequestFlush = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<RequestFlush>): RequestFlush {
-    const message = { ...baseRequestFlush } as RequestFlush;
-    return message;
-  },
-
   toJSON(_: RequestFlush): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<RequestFlush>): RequestFlush {
+    const message = { ...baseRequestFlush } as RequestFlush;
+    return message;
   },
 };
 
@@ -1060,9 +1062,15 @@ export const RequestInfo = {
     message: RequestInfo,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.version);
-    writer.uint32(16).uint64(message.blockVersion);
-    writer.uint32(24).uint64(message.p2pVersion);
+    if (message.version !== '') {
+      writer.uint32(10).string(message.version);
+    }
+    if (!message.blockVersion.isZero()) {
+      writer.uint32(16).uint64(message.blockVersion);
+    }
+    if (!message.p2pVersion.isZero()) {
+      writer.uint32(24).uint64(message.p2pVersion);
+    }
     return writer;
   },
 
@@ -1110,6 +1118,16 @@ export const RequestInfo = {
     return message;
   },
 
+  toJSON(message: RequestInfo): unknown {
+    const obj: any = {};
+    message.version !== undefined && (obj.version = message.version);
+    message.blockVersion !== undefined &&
+      (obj.blockVersion = (message.blockVersion || Long.UZERO).toString());
+    message.p2pVersion !== undefined &&
+      (obj.p2pVersion = (message.p2pVersion || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestInfo>): RequestInfo {
     const message = { ...baseRequestInfo } as RequestInfo;
     if (object.version !== undefined && object.version !== null) {
@@ -1129,16 +1147,6 @@ export const RequestInfo = {
     }
     return message;
   },
-
-  toJSON(message: RequestInfo): unknown {
-    const obj: any = {};
-    message.version !== undefined && (obj.version = message.version);
-    message.blockVersion !== undefined &&
-      (obj.blockVersion = (message.blockVersion || Long.UZERO).toString());
-    message.p2pVersion !== undefined &&
-      (obj.p2pVersion = (message.p2pVersion || Long.UZERO).toString());
-    return obj;
-  },
 };
 
 const baseRequestSetOption: object = { key: '', value: '' };
@@ -1148,8 +1156,12 @@ export const RequestSetOption = {
     message: RequestSetOption,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.key);
-    writer.uint32(18).string(message.value);
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== '') {
+      writer.uint32(18).string(message.value);
+    }
     return writer;
   },
 
@@ -1189,6 +1201,13 @@ export const RequestSetOption = {
     return message;
   },
 
+  toJSON(message: RequestSetOption): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestSetOption>): RequestSetOption {
     const message = { ...baseRequestSetOption } as RequestSetOption;
     if (object.key !== undefined && object.key !== null) {
@@ -1203,13 +1222,6 @@ export const RequestSetOption = {
     }
     return message;
   },
-
-  toJSON(message: RequestSetOption): unknown {
-    const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
-    return obj;
-  },
 };
 
 const baseRequestInitChain: object = { chainId: '', initialHeight: Long.ZERO };
@@ -1219,14 +1231,13 @@ export const RequestInitChain = {
     message: RequestInitChain,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.time !== undefined && message.time !== undefined) {
+    if (message.time !== undefined) {
       Timestamp.encode(message.time, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.chainId);
-    if (
-      message.consensusParams !== undefined &&
-      message.consensusParams !== undefined
-    ) {
+    if (message.chainId !== '') {
+      writer.uint32(18).string(message.chainId);
+    }
+    if (message.consensusParams !== undefined) {
       ConsensusParams.encode(
         message.consensusParams,
         writer.uint32(26).fork()
@@ -1235,8 +1246,12 @@ export const RequestInitChain = {
     for (const v of message.validators) {
       ValidatorUpdate.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(42).bytes(message.appStateBytes);
-    writer.uint32(48).int64(message.initialHeight);
+    if (message.appStateBytes.length !== 0) {
+      writer.uint32(42).bytes(message.appStateBytes);
+    }
+    if (!message.initialHeight.isZero()) {
+      writer.uint32(48).int64(message.initialHeight);
+    }
     return writer;
   },
 
@@ -1318,6 +1333,36 @@ export const RequestInitChain = {
     return message;
   },
 
+  toJSON(message: RequestInitChain): unknown {
+    const obj: any = {};
+    message.time !== undefined &&
+      (obj.time =
+        message.time !== undefined
+          ? fromTimestamp(message.time).toISOString()
+          : null);
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.consensusParams !== undefined &&
+      (obj.consensusParams = message.consensusParams
+        ? ConsensusParams.toJSON(message.consensusParams)
+        : undefined);
+    if (message.validators) {
+      obj.validators = message.validators.map((e) =>
+        e ? ValidatorUpdate.toJSON(e) : undefined
+      );
+    } else {
+      obj.validators = [];
+    }
+    message.appStateBytes !== undefined &&
+      (obj.appStateBytes = base64FromBytes(
+        message.appStateBytes !== undefined
+          ? message.appStateBytes
+          : new Uint8Array()
+      ));
+    message.initialHeight !== undefined &&
+      (obj.initialHeight = (message.initialHeight || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestInitChain>): RequestInitChain {
     const message = { ...baseRequestInitChain } as RequestInitChain;
     message.validators = [];
@@ -1358,36 +1403,6 @@ export const RequestInitChain = {
     }
     return message;
   },
-
-  toJSON(message: RequestInitChain): unknown {
-    const obj: any = {};
-    message.time !== undefined &&
-      (obj.time =
-        message.time !== undefined
-          ? fromTimestamp(message.time).toISOString()
-          : null);
-    message.chainId !== undefined && (obj.chainId = message.chainId);
-    message.consensusParams !== undefined &&
-      (obj.consensusParams = message.consensusParams
-        ? ConsensusParams.toJSON(message.consensusParams)
-        : undefined);
-    if (message.validators) {
-      obj.validators = message.validators.map((e) =>
-        e ? ValidatorUpdate.toJSON(e) : undefined
-      );
-    } else {
-      obj.validators = [];
-    }
-    message.appStateBytes !== undefined &&
-      (obj.appStateBytes = base64FromBytes(
-        message.appStateBytes !== undefined
-          ? message.appStateBytes
-          : new Uint8Array()
-      ));
-    message.initialHeight !== undefined &&
-      (obj.initialHeight = (message.initialHeight || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseRequestQuery: object = { path: '', height: Long.ZERO, prove: false };
@@ -1397,10 +1412,18 @@ export const RequestQuery = {
     message: RequestQuery,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.data);
-    writer.uint32(18).string(message.path);
-    writer.uint32(24).int64(message.height);
-    writer.uint32(32).bool(message.prove);
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    if (message.path !== '') {
+      writer.uint32(18).string(message.path);
+    }
+    if (!message.height.isZero()) {
+      writer.uint32(24).int64(message.height);
+    }
+    if (message.prove === true) {
+      writer.uint32(32).bool(message.prove);
+    }
     return writer;
   },
 
@@ -1454,6 +1477,19 @@ export const RequestQuery = {
     return message;
   },
 
+  toJSON(message: RequestQuery): unknown {
+    const obj: any = {};
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.path !== undefined && (obj.path = message.path);
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.prove !== undefined && (obj.prove = message.prove);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestQuery>): RequestQuery {
     const message = { ...baseRequestQuery } as RequestQuery;
     if (object.data !== undefined && object.data !== null) {
@@ -1478,19 +1514,6 @@ export const RequestQuery = {
     }
     return message;
   },
-
-  toJSON(message: RequestQuery): unknown {
-    const obj: any = {};
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.path !== undefined && (obj.path = message.path);
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.prove !== undefined && (obj.prove = message.prove);
-    return obj;
-  },
 };
 
 const baseRequestBeginBlock: object = {};
@@ -1500,14 +1523,13 @@ export const RequestBeginBlock = {
     message: RequestBeginBlock,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.hash);
-    if (message.header !== undefined && message.header !== undefined) {
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
+    if (message.header !== undefined) {
       Header.encode(message.header, writer.uint32(18).fork()).ldelim();
     }
-    if (
-      message.lastCommitInfo !== undefined &&
-      message.lastCommitInfo !== undefined
-    ) {
+    if (message.lastCommitInfo !== undefined) {
       LastCommitInfo.encode(
         message.lastCommitInfo,
         writer.uint32(26).fork()
@@ -1579,6 +1601,28 @@ export const RequestBeginBlock = {
     return message;
   },
 
+  toJSON(message: RequestBeginBlock): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(
+        message.hash !== undefined ? message.hash : new Uint8Array()
+      ));
+    message.header !== undefined &&
+      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
+    message.lastCommitInfo !== undefined &&
+      (obj.lastCommitInfo = message.lastCommitInfo
+        ? LastCommitInfo.toJSON(message.lastCommitInfo)
+        : undefined);
+    if (message.byzantineValidators) {
+      obj.byzantineValidators = message.byzantineValidators.map((e) =>
+        e ? Evidence.toJSON(e) : undefined
+      );
+    } else {
+      obj.byzantineValidators = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestBeginBlock>): RequestBeginBlock {
     const message = { ...baseRequestBeginBlock } as RequestBeginBlock;
     message.byzantineValidators = [];
@@ -1609,28 +1653,6 @@ export const RequestBeginBlock = {
     }
     return message;
   },
-
-  toJSON(message: RequestBeginBlock): unknown {
-    const obj: any = {};
-    message.hash !== undefined &&
-      (obj.hash = base64FromBytes(
-        message.hash !== undefined ? message.hash : new Uint8Array()
-      ));
-    message.header !== undefined &&
-      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
-    message.lastCommitInfo !== undefined &&
-      (obj.lastCommitInfo = message.lastCommitInfo
-        ? LastCommitInfo.toJSON(message.lastCommitInfo)
-        : undefined);
-    if (message.byzantineValidators) {
-      obj.byzantineValidators = message.byzantineValidators.map((e) =>
-        e ? Evidence.toJSON(e) : undefined
-      );
-    } else {
-      obj.byzantineValidators = [];
-    }
-    return obj;
-  },
 };
 
 const baseRequestCheckTx: object = { type: 0 };
@@ -1640,8 +1662,12 @@ export const RequestCheckTx = {
     message: RequestCheckTx,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.tx);
-    writer.uint32(16).int32(message.type);
+    if (message.tx.length !== 0) {
+      writer.uint32(10).bytes(message.tx);
+    }
+    if (message.type !== 0) {
+      writer.uint32(16).int32(message.type);
+    }
     return writer;
   },
 
@@ -1679,6 +1705,16 @@ export const RequestCheckTx = {
     return message;
   },
 
+  toJSON(message: RequestCheckTx): unknown {
+    const obj: any = {};
+    message.tx !== undefined &&
+      (obj.tx = base64FromBytes(
+        message.tx !== undefined ? message.tx : new Uint8Array()
+      ));
+    message.type !== undefined && (obj.type = checkTxTypeToJSON(message.type));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestCheckTx>): RequestCheckTx {
     const message = { ...baseRequestCheckTx } as RequestCheckTx;
     if (object.tx !== undefined && object.tx !== null) {
@@ -1693,16 +1729,6 @@ export const RequestCheckTx = {
     }
     return message;
   },
-
-  toJSON(message: RequestCheckTx): unknown {
-    const obj: any = {};
-    message.tx !== undefined &&
-      (obj.tx = base64FromBytes(
-        message.tx !== undefined ? message.tx : new Uint8Array()
-      ));
-    message.type !== undefined && (obj.type = checkTxTypeToJSON(message.type));
-    return obj;
-  },
 };
 
 const baseRequestDeliverTx: object = {};
@@ -1712,7 +1738,9 @@ export const RequestDeliverTx = {
     message: RequestDeliverTx,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.tx);
+    if (message.tx.length !== 0) {
+      writer.uint32(10).bytes(message.tx);
+    }
     return writer;
   },
 
@@ -1742,6 +1770,15 @@ export const RequestDeliverTx = {
     return message;
   },
 
+  toJSON(message: RequestDeliverTx): unknown {
+    const obj: any = {};
+    message.tx !== undefined &&
+      (obj.tx = base64FromBytes(
+        message.tx !== undefined ? message.tx : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestDeliverTx>): RequestDeliverTx {
     const message = { ...baseRequestDeliverTx } as RequestDeliverTx;
     if (object.tx !== undefined && object.tx !== null) {
@@ -1750,15 +1787,6 @@ export const RequestDeliverTx = {
       message.tx = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: RequestDeliverTx): unknown {
-    const obj: any = {};
-    message.tx !== undefined &&
-      (obj.tx = base64FromBytes(
-        message.tx !== undefined ? message.tx : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -1769,7 +1797,9 @@ export const RequestEndBlock = {
     message: RequestEndBlock,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.height);
+    if (!message.height.isZero()) {
+      writer.uint32(8).int64(message.height);
+    }
     return writer;
   },
 
@@ -1801,6 +1831,13 @@ export const RequestEndBlock = {
     return message;
   },
 
+  toJSON(message: RequestEndBlock): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestEndBlock>): RequestEndBlock {
     const message = { ...baseRequestEndBlock } as RequestEndBlock;
     if (object.height !== undefined && object.height !== null) {
@@ -1809,13 +1846,6 @@ export const RequestEndBlock = {
       message.height = Long.ZERO;
     }
     return message;
-  },
-
-  toJSON(message: RequestEndBlock): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    return obj;
   },
 };
 
@@ -1849,14 +1879,14 @@ export const RequestCommit = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<RequestCommit>): RequestCommit {
-    const message = { ...baseRequestCommit } as RequestCommit;
-    return message;
-  },
-
   toJSON(_: RequestCommit): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<RequestCommit>): RequestCommit {
+    const message = { ...baseRequestCommit } as RequestCommit;
+    return message;
   },
 };
 
@@ -1893,14 +1923,14 @@ export const RequestListSnapshots = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<RequestListSnapshots>): RequestListSnapshots {
-    const message = { ...baseRequestListSnapshots } as RequestListSnapshots;
-    return message;
-  },
-
   toJSON(_: RequestListSnapshots): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<RequestListSnapshots>): RequestListSnapshots {
+    const message = { ...baseRequestListSnapshots } as RequestListSnapshots;
+    return message;
   },
 };
 
@@ -1911,10 +1941,12 @@ export const RequestOfferSnapshot = {
     message: RequestOfferSnapshot,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.snapshot !== undefined && message.snapshot !== undefined) {
+    if (message.snapshot !== undefined) {
       Snapshot.encode(message.snapshot, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).bytes(message.appHash);
+    if (message.appHash.length !== 0) {
+      writer.uint32(18).bytes(message.appHash);
+    }
     return writer;
   },
 
@@ -1955,6 +1987,19 @@ export const RequestOfferSnapshot = {
     return message;
   },
 
+  toJSON(message: RequestOfferSnapshot): unknown {
+    const obj: any = {};
+    message.snapshot !== undefined &&
+      (obj.snapshot = message.snapshot
+        ? Snapshot.toJSON(message.snapshot)
+        : undefined);
+    message.appHash !== undefined &&
+      (obj.appHash = base64FromBytes(
+        message.appHash !== undefined ? message.appHash : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<RequestOfferSnapshot>): RequestOfferSnapshot {
     const message = { ...baseRequestOfferSnapshot } as RequestOfferSnapshot;
     if (object.snapshot !== undefined && object.snapshot !== null) {
@@ -1969,19 +2014,6 @@ export const RequestOfferSnapshot = {
     }
     return message;
   },
-
-  toJSON(message: RequestOfferSnapshot): unknown {
-    const obj: any = {};
-    message.snapshot !== undefined &&
-      (obj.snapshot = message.snapshot
-        ? Snapshot.toJSON(message.snapshot)
-        : undefined);
-    message.appHash !== undefined &&
-      (obj.appHash = base64FromBytes(
-        message.appHash !== undefined ? message.appHash : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseRequestLoadSnapshotChunk: object = {
@@ -1995,9 +2027,15 @@ export const RequestLoadSnapshotChunk = {
     message: RequestLoadSnapshotChunk,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.height);
-    writer.uint32(16).uint32(message.format);
-    writer.uint32(24).uint32(message.chunk);
+    if (!message.height.isZero()) {
+      writer.uint32(8).uint64(message.height);
+    }
+    if (message.format !== 0) {
+      writer.uint32(16).uint32(message.format);
+    }
+    if (message.chunk !== 0) {
+      writer.uint32(24).uint32(message.chunk);
+    }
     return writer;
   },
 
@@ -2052,6 +2090,15 @@ export const RequestLoadSnapshotChunk = {
     return message;
   },
 
+  toJSON(message: RequestLoadSnapshotChunk): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.UZERO).toString());
+    message.format !== undefined && (obj.format = message.format);
+    message.chunk !== undefined && (obj.chunk = message.chunk);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<RequestLoadSnapshotChunk>
   ): RequestLoadSnapshotChunk {
@@ -2075,15 +2122,6 @@ export const RequestLoadSnapshotChunk = {
     }
     return message;
   },
-
-  toJSON(message: RequestLoadSnapshotChunk): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.UZERO).toString());
-    message.format !== undefined && (obj.format = message.format);
-    message.chunk !== undefined && (obj.chunk = message.chunk);
-    return obj;
-  },
 };
 
 const baseRequestApplySnapshotChunk: object = { index: 0, sender: '' };
@@ -2093,9 +2131,15 @@ export const RequestApplySnapshotChunk = {
     message: RequestApplySnapshotChunk,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.index);
-    writer.uint32(18).bytes(message.chunk);
-    writer.uint32(26).string(message.sender);
+    if (message.index !== 0) {
+      writer.uint32(8).uint32(message.index);
+    }
+    if (message.chunk.length !== 0) {
+      writer.uint32(18).bytes(message.chunk);
+    }
+    if (message.sender !== '') {
+      writer.uint32(26).string(message.sender);
+    }
     return writer;
   },
 
@@ -2148,6 +2192,17 @@ export const RequestApplySnapshotChunk = {
     return message;
   },
 
+  toJSON(message: RequestApplySnapshotChunk): unknown {
+    const obj: any = {};
+    message.index !== undefined && (obj.index = message.index);
+    message.chunk !== undefined &&
+      (obj.chunk = base64FromBytes(
+        message.chunk !== undefined ? message.chunk : new Uint8Array()
+      ));
+    message.sender !== undefined && (obj.sender = message.sender);
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<RequestApplySnapshotChunk>
   ): RequestApplySnapshotChunk {
@@ -2170,17 +2225,6 @@ export const RequestApplySnapshotChunk = {
       message.sender = '';
     }
     return message;
-  },
-
-  toJSON(message: RequestApplySnapshotChunk): unknown {
-    const obj: any = {};
-    message.index !== undefined && (obj.index = message.index);
-    message.chunk !== undefined &&
-      (obj.chunk = base64FromBytes(
-        message.chunk !== undefined ? message.chunk : new Uint8Array()
-      ));
-    message.sender !== undefined && (obj.sender = message.sender);
-    return obj;
   },
 };
 
@@ -2452,6 +2496,71 @@ export const Response = {
     return message;
   },
 
+  toJSON(message: Response): unknown {
+    const obj: any = {};
+    message.exception !== undefined &&
+      (obj.exception = message.exception
+        ? ResponseException.toJSON(message.exception)
+        : undefined);
+    message.echo !== undefined &&
+      (obj.echo = message.echo ? ResponseEcho.toJSON(message.echo) : undefined);
+    message.flush !== undefined &&
+      (obj.flush = message.flush
+        ? ResponseFlush.toJSON(message.flush)
+        : undefined);
+    message.info !== undefined &&
+      (obj.info = message.info ? ResponseInfo.toJSON(message.info) : undefined);
+    message.setOption !== undefined &&
+      (obj.setOption = message.setOption
+        ? ResponseSetOption.toJSON(message.setOption)
+        : undefined);
+    message.initChain !== undefined &&
+      (obj.initChain = message.initChain
+        ? ResponseInitChain.toJSON(message.initChain)
+        : undefined);
+    message.query !== undefined &&
+      (obj.query = message.query
+        ? ResponseQuery.toJSON(message.query)
+        : undefined);
+    message.beginBlock !== undefined &&
+      (obj.beginBlock = message.beginBlock
+        ? ResponseBeginBlock.toJSON(message.beginBlock)
+        : undefined);
+    message.checkTx !== undefined &&
+      (obj.checkTx = message.checkTx
+        ? ResponseCheckTx.toJSON(message.checkTx)
+        : undefined);
+    message.deliverTx !== undefined &&
+      (obj.deliverTx = message.deliverTx
+        ? ResponseDeliverTx.toJSON(message.deliverTx)
+        : undefined);
+    message.endBlock !== undefined &&
+      (obj.endBlock = message.endBlock
+        ? ResponseEndBlock.toJSON(message.endBlock)
+        : undefined);
+    message.commit !== undefined &&
+      (obj.commit = message.commit
+        ? ResponseCommit.toJSON(message.commit)
+        : undefined);
+    message.listSnapshots !== undefined &&
+      (obj.listSnapshots = message.listSnapshots
+        ? ResponseListSnapshots.toJSON(message.listSnapshots)
+        : undefined);
+    message.offerSnapshot !== undefined &&
+      (obj.offerSnapshot = message.offerSnapshot
+        ? ResponseOfferSnapshot.toJSON(message.offerSnapshot)
+        : undefined);
+    message.loadSnapshotChunk !== undefined &&
+      (obj.loadSnapshotChunk = message.loadSnapshotChunk
+        ? ResponseLoadSnapshotChunk.toJSON(message.loadSnapshotChunk)
+        : undefined);
+    message.applySnapshotChunk !== undefined &&
+      (obj.applySnapshotChunk = message.applySnapshotChunk
+        ? ResponseApplySnapshotChunk.toJSON(message.applySnapshotChunk)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Response>): Response {
     const message = { ...baseResponse } as Response;
     if (object.exception !== undefined && object.exception !== null) {
@@ -2550,71 +2659,6 @@ export const Response = {
     }
     return message;
   },
-
-  toJSON(message: Response): unknown {
-    const obj: any = {};
-    message.exception !== undefined &&
-      (obj.exception = message.exception
-        ? ResponseException.toJSON(message.exception)
-        : undefined);
-    message.echo !== undefined &&
-      (obj.echo = message.echo ? ResponseEcho.toJSON(message.echo) : undefined);
-    message.flush !== undefined &&
-      (obj.flush = message.flush
-        ? ResponseFlush.toJSON(message.flush)
-        : undefined);
-    message.info !== undefined &&
-      (obj.info = message.info ? ResponseInfo.toJSON(message.info) : undefined);
-    message.setOption !== undefined &&
-      (obj.setOption = message.setOption
-        ? ResponseSetOption.toJSON(message.setOption)
-        : undefined);
-    message.initChain !== undefined &&
-      (obj.initChain = message.initChain
-        ? ResponseInitChain.toJSON(message.initChain)
-        : undefined);
-    message.query !== undefined &&
-      (obj.query = message.query
-        ? ResponseQuery.toJSON(message.query)
-        : undefined);
-    message.beginBlock !== undefined &&
-      (obj.beginBlock = message.beginBlock
-        ? ResponseBeginBlock.toJSON(message.beginBlock)
-        : undefined);
-    message.checkTx !== undefined &&
-      (obj.checkTx = message.checkTx
-        ? ResponseCheckTx.toJSON(message.checkTx)
-        : undefined);
-    message.deliverTx !== undefined &&
-      (obj.deliverTx = message.deliverTx
-        ? ResponseDeliverTx.toJSON(message.deliverTx)
-        : undefined);
-    message.endBlock !== undefined &&
-      (obj.endBlock = message.endBlock
-        ? ResponseEndBlock.toJSON(message.endBlock)
-        : undefined);
-    message.commit !== undefined &&
-      (obj.commit = message.commit
-        ? ResponseCommit.toJSON(message.commit)
-        : undefined);
-    message.listSnapshots !== undefined &&
-      (obj.listSnapshots = message.listSnapshots
-        ? ResponseListSnapshots.toJSON(message.listSnapshots)
-        : undefined);
-    message.offerSnapshot !== undefined &&
-      (obj.offerSnapshot = message.offerSnapshot
-        ? ResponseOfferSnapshot.toJSON(message.offerSnapshot)
-        : undefined);
-    message.loadSnapshotChunk !== undefined &&
-      (obj.loadSnapshotChunk = message.loadSnapshotChunk
-        ? ResponseLoadSnapshotChunk.toJSON(message.loadSnapshotChunk)
-        : undefined);
-    message.applySnapshotChunk !== undefined &&
-      (obj.applySnapshotChunk = message.applySnapshotChunk
-        ? ResponseApplySnapshotChunk.toJSON(message.applySnapshotChunk)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseResponseException: object = { error: '' };
@@ -2624,7 +2668,9 @@ export const ResponseException = {
     message: ResponseException,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.error);
+    if (message.error !== '') {
+      writer.uint32(10).string(message.error);
+    }
     return writer;
   },
 
@@ -2656,6 +2702,12 @@ export const ResponseException = {
     return message;
   },
 
+  toJSON(message: ResponseException): unknown {
+    const obj: any = {};
+    message.error !== undefined && (obj.error = message.error);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseException>): ResponseException {
     const message = { ...baseResponseException } as ResponseException;
     if (object.error !== undefined && object.error !== null) {
@@ -2664,12 +2716,6 @@ export const ResponseException = {
       message.error = '';
     }
     return message;
-  },
-
-  toJSON(message: ResponseException): unknown {
-    const obj: any = {};
-    message.error !== undefined && (obj.error = message.error);
-    return obj;
   },
 };
 
@@ -2680,7 +2726,9 @@ export const ResponseEcho = {
     message: ResponseEcho,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.message);
+    if (message.message !== '') {
+      writer.uint32(10).string(message.message);
+    }
     return writer;
   },
 
@@ -2712,6 +2760,12 @@ export const ResponseEcho = {
     return message;
   },
 
+  toJSON(message: ResponseEcho): unknown {
+    const obj: any = {};
+    message.message !== undefined && (obj.message = message.message);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseEcho>): ResponseEcho {
     const message = { ...baseResponseEcho } as ResponseEcho;
     if (object.message !== undefined && object.message !== null) {
@@ -2720,12 +2774,6 @@ export const ResponseEcho = {
       message.message = '';
     }
     return message;
-  },
-
-  toJSON(message: ResponseEcho): unknown {
-    const obj: any = {};
-    message.message !== undefined && (obj.message = message.message);
-    return obj;
   },
 };
 
@@ -2759,14 +2807,14 @@ export const ResponseFlush = {
     return message;
   },
 
-  fromPartial(_: DeepPartial<ResponseFlush>): ResponseFlush {
-    const message = { ...baseResponseFlush } as ResponseFlush;
-    return message;
-  },
-
   toJSON(_: ResponseFlush): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  fromPartial(_: DeepPartial<ResponseFlush>): ResponseFlush {
+    const message = { ...baseResponseFlush } as ResponseFlush;
+    return message;
   },
 };
 
@@ -2782,11 +2830,21 @@ export const ResponseInfo = {
     message: ResponseInfo,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.data);
-    writer.uint32(18).string(message.version);
-    writer.uint32(24).uint64(message.appVersion);
-    writer.uint32(32).int64(message.lastBlockHeight);
-    writer.uint32(42).bytes(message.lastBlockAppHash);
+    if (message.data !== '') {
+      writer.uint32(10).string(message.data);
+    }
+    if (message.version !== '') {
+      writer.uint32(18).string(message.version);
+    }
+    if (!message.appVersion.isZero()) {
+      writer.uint32(24).uint64(message.appVersion);
+    }
+    if (!message.lastBlockHeight.isZero()) {
+      writer.uint32(32).int64(message.lastBlockHeight);
+    }
+    if (message.lastBlockAppHash.length !== 0) {
+      writer.uint32(42).bytes(message.lastBlockAppHash);
+    }
     return writer;
   },
 
@@ -2854,6 +2912,23 @@ export const ResponseInfo = {
     return message;
   },
 
+  toJSON(message: ResponseInfo): unknown {
+    const obj: any = {};
+    message.data !== undefined && (obj.data = message.data);
+    message.version !== undefined && (obj.version = message.version);
+    message.appVersion !== undefined &&
+      (obj.appVersion = (message.appVersion || Long.UZERO).toString());
+    message.lastBlockHeight !== undefined &&
+      (obj.lastBlockHeight = (message.lastBlockHeight || Long.ZERO).toString());
+    message.lastBlockAppHash !== undefined &&
+      (obj.lastBlockAppHash = base64FromBytes(
+        message.lastBlockAppHash !== undefined
+          ? message.lastBlockAppHash
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseInfo>): ResponseInfo {
     const message = { ...baseResponseInfo } as ResponseInfo;
     if (object.data !== undefined && object.data !== null) {
@@ -2889,23 +2964,6 @@ export const ResponseInfo = {
     }
     return message;
   },
-
-  toJSON(message: ResponseInfo): unknown {
-    const obj: any = {};
-    message.data !== undefined && (obj.data = message.data);
-    message.version !== undefined && (obj.version = message.version);
-    message.appVersion !== undefined &&
-      (obj.appVersion = (message.appVersion || Long.UZERO).toString());
-    message.lastBlockHeight !== undefined &&
-      (obj.lastBlockHeight = (message.lastBlockHeight || Long.ZERO).toString());
-    message.lastBlockAppHash !== undefined &&
-      (obj.lastBlockAppHash = base64FromBytes(
-        message.lastBlockAppHash !== undefined
-          ? message.lastBlockAppHash
-          : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseResponseSetOption: object = { code: 0, log: '', info: '' };
@@ -2915,9 +2973,15 @@ export const ResponseSetOption = {
     message: ResponseSetOption,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.code);
-    writer.uint32(26).string(message.log);
-    writer.uint32(34).string(message.info);
+    if (message.code !== 0) {
+      writer.uint32(8).uint32(message.code);
+    }
+    if (message.log !== '') {
+      writer.uint32(26).string(message.log);
+    }
+    if (message.info !== '') {
+      writer.uint32(34).string(message.info);
+    }
     return writer;
   },
 
@@ -2965,6 +3029,14 @@ export const ResponseSetOption = {
     return message;
   },
 
+  toJSON(message: ResponseSetOption): unknown {
+    const obj: any = {};
+    message.code !== undefined && (obj.code = message.code);
+    message.log !== undefined && (obj.log = message.log);
+    message.info !== undefined && (obj.info = message.info);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseSetOption>): ResponseSetOption {
     const message = { ...baseResponseSetOption } as ResponseSetOption;
     if (object.code !== undefined && object.code !== null) {
@@ -2984,14 +3056,6 @@ export const ResponseSetOption = {
     }
     return message;
   },
-
-  toJSON(message: ResponseSetOption): unknown {
-    const obj: any = {};
-    message.code !== undefined && (obj.code = message.code);
-    message.log !== undefined && (obj.log = message.log);
-    message.info !== undefined && (obj.info = message.info);
-    return obj;
-  },
 };
 
 const baseResponseInitChain: object = {};
@@ -3001,10 +3065,7 @@ export const ResponseInitChain = {
     message: ResponseInitChain,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.consensusParams !== undefined &&
-      message.consensusParams !== undefined
-    ) {
+    if (message.consensusParams !== undefined) {
       ConsensusParams.encode(
         message.consensusParams,
         writer.uint32(10).fork()
@@ -3013,7 +3074,9 @@ export const ResponseInitChain = {
     for (const v of message.validators) {
       ValidatorUpdate.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).bytes(message.appHash);
+    if (message.appHash.length !== 0) {
+      writer.uint32(26).bytes(message.appHash);
+    }
     return writer;
   },
 
@@ -3071,6 +3134,26 @@ export const ResponseInitChain = {
     return message;
   },
 
+  toJSON(message: ResponseInitChain): unknown {
+    const obj: any = {};
+    message.consensusParams !== undefined &&
+      (obj.consensusParams = message.consensusParams
+        ? ConsensusParams.toJSON(message.consensusParams)
+        : undefined);
+    if (message.validators) {
+      obj.validators = message.validators.map((e) =>
+        e ? ValidatorUpdate.toJSON(e) : undefined
+      );
+    } else {
+      obj.validators = [];
+    }
+    message.appHash !== undefined &&
+      (obj.appHash = base64FromBytes(
+        message.appHash !== undefined ? message.appHash : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseInitChain>): ResponseInitChain {
     const message = { ...baseResponseInitChain } as ResponseInitChain;
     message.validators = [];
@@ -3096,26 +3179,6 @@ export const ResponseInitChain = {
     }
     return message;
   },
-
-  toJSON(message: ResponseInitChain): unknown {
-    const obj: any = {};
-    message.consensusParams !== undefined &&
-      (obj.consensusParams = message.consensusParams
-        ? ConsensusParams.toJSON(message.consensusParams)
-        : undefined);
-    if (message.validators) {
-      obj.validators = message.validators.map((e) =>
-        e ? ValidatorUpdate.toJSON(e) : undefined
-      );
-    } else {
-      obj.validators = [];
-    }
-    message.appHash !== undefined &&
-      (obj.appHash = base64FromBytes(
-        message.appHash !== undefined ? message.appHash : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseResponseQuery: object = {
@@ -3132,17 +3195,33 @@ export const ResponseQuery = {
     message: ResponseQuery,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.code);
-    writer.uint32(26).string(message.log);
-    writer.uint32(34).string(message.info);
-    writer.uint32(40).int64(message.index);
-    writer.uint32(50).bytes(message.key);
-    writer.uint32(58).bytes(message.value);
-    if (message.proofOps !== undefined && message.proofOps !== undefined) {
+    if (message.code !== 0) {
+      writer.uint32(8).uint32(message.code);
+    }
+    if (message.log !== '') {
+      writer.uint32(26).string(message.log);
+    }
+    if (message.info !== '') {
+      writer.uint32(34).string(message.info);
+    }
+    if (!message.index.isZero()) {
+      writer.uint32(40).int64(message.index);
+    }
+    if (message.key.length !== 0) {
+      writer.uint32(50).bytes(message.key);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(58).bytes(message.value);
+    }
+    if (message.proofOps !== undefined) {
       ProofOps.encode(message.proofOps, writer.uint32(66).fork()).ldelim();
     }
-    writer.uint32(72).int64(message.height);
-    writer.uint32(82).string(message.codespace);
+    if (!message.height.isZero()) {
+      writer.uint32(72).int64(message.height);
+    }
+    if (message.codespace !== '') {
+      writer.uint32(82).string(message.codespace);
+    }
     return writer;
   },
 
@@ -3234,6 +3313,31 @@ export const ResponseQuery = {
     return message;
   },
 
+  toJSON(message: ResponseQuery): unknown {
+    const obj: any = {};
+    message.code !== undefined && (obj.code = message.code);
+    message.log !== undefined && (obj.log = message.log);
+    message.info !== undefined && (obj.info = message.info);
+    message.index !== undefined &&
+      (obj.index = (message.index || Long.ZERO).toString());
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    message.proofOps !== undefined &&
+      (obj.proofOps = message.proofOps
+        ? ProofOps.toJSON(message.proofOps)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.codespace !== undefined && (obj.codespace = message.codespace);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseQuery>): ResponseQuery {
     const message = { ...baseResponseQuery } as ResponseQuery;
     if (object.code !== undefined && object.code !== null) {
@@ -3283,31 +3387,6 @@ export const ResponseQuery = {
     }
     return message;
   },
-
-  toJSON(message: ResponseQuery): unknown {
-    const obj: any = {};
-    message.code !== undefined && (obj.code = message.code);
-    message.log !== undefined && (obj.log = message.log);
-    message.info !== undefined && (obj.info = message.info);
-    message.index !== undefined &&
-      (obj.index = (message.index || Long.ZERO).toString());
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    message.proofOps !== undefined &&
-      (obj.proofOps = message.proofOps
-        ? ProofOps.toJSON(message.proofOps)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.codespace !== undefined && (obj.codespace = message.codespace);
-    return obj;
-  },
 };
 
 const baseResponseBeginBlock: object = {};
@@ -3353,6 +3432,16 @@ export const ResponseBeginBlock = {
     return message;
   },
 
+  toJSON(message: ResponseBeginBlock): unknown {
+    const obj: any = {};
+    if (message.events) {
+      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
+    } else {
+      obj.events = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseBeginBlock>): ResponseBeginBlock {
     const message = { ...baseResponseBeginBlock } as ResponseBeginBlock;
     message.events = [];
@@ -3362,16 +3451,6 @@ export const ResponseBeginBlock = {
       }
     }
     return message;
-  },
-
-  toJSON(message: ResponseBeginBlock): unknown {
-    const obj: any = {};
-    if (message.events) {
-      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
-    } else {
-      obj.events = [];
-    }
-    return obj;
   },
 };
 
@@ -3389,16 +3468,30 @@ export const ResponseCheckTx = {
     message: ResponseCheckTx,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.code);
-    writer.uint32(18).bytes(message.data);
-    writer.uint32(26).string(message.log);
-    writer.uint32(34).string(message.info);
-    writer.uint32(40).int64(message.gasWanted);
-    writer.uint32(48).int64(message.gasUsed);
+    if (message.code !== 0) {
+      writer.uint32(8).uint32(message.code);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(18).bytes(message.data);
+    }
+    if (message.log !== '') {
+      writer.uint32(26).string(message.log);
+    }
+    if (message.info !== '') {
+      writer.uint32(34).string(message.info);
+    }
+    if (!message.gasWanted.isZero()) {
+      writer.uint32(40).int64(message.gasWanted);
+    }
+    if (!message.gasUsed.isZero()) {
+      writer.uint32(48).int64(message.gasUsed);
+    }
     for (const v of message.events) {
       Event.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    writer.uint32(66).string(message.codespace);
+    if (message.codespace !== '') {
+      writer.uint32(66).string(message.codespace);
+    }
     return writer;
   },
 
@@ -3486,6 +3579,28 @@ export const ResponseCheckTx = {
     return message;
   },
 
+  toJSON(message: ResponseCheckTx): unknown {
+    const obj: any = {};
+    message.code !== undefined && (obj.code = message.code);
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.log !== undefined && (obj.log = message.log);
+    message.info !== undefined && (obj.info = message.info);
+    message.gasWanted !== undefined &&
+      (obj.gasWanted = (message.gasWanted || Long.ZERO).toString());
+    message.gasUsed !== undefined &&
+      (obj.gasUsed = (message.gasUsed || Long.ZERO).toString());
+    if (message.events) {
+      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
+    } else {
+      obj.events = [];
+    }
+    message.codespace !== undefined && (obj.codespace = message.codespace);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseCheckTx>): ResponseCheckTx {
     const message = { ...baseResponseCheckTx } as ResponseCheckTx;
     message.events = [];
@@ -3531,28 +3646,6 @@ export const ResponseCheckTx = {
     }
     return message;
   },
-
-  toJSON(message: ResponseCheckTx): unknown {
-    const obj: any = {};
-    message.code !== undefined && (obj.code = message.code);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.log !== undefined && (obj.log = message.log);
-    message.info !== undefined && (obj.info = message.info);
-    message.gasWanted !== undefined &&
-      (obj.gasWanted = (message.gasWanted || Long.ZERO).toString());
-    message.gasUsed !== undefined &&
-      (obj.gasUsed = (message.gasUsed || Long.ZERO).toString());
-    if (message.events) {
-      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
-    } else {
-      obj.events = [];
-    }
-    message.codespace !== undefined && (obj.codespace = message.codespace);
-    return obj;
-  },
 };
 
 const baseResponseDeliverTx: object = {
@@ -3569,16 +3662,30 @@ export const ResponseDeliverTx = {
     message: ResponseDeliverTx,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.code);
-    writer.uint32(18).bytes(message.data);
-    writer.uint32(26).string(message.log);
-    writer.uint32(34).string(message.info);
-    writer.uint32(40).int64(message.gasWanted);
-    writer.uint32(48).int64(message.gasUsed);
+    if (message.code !== 0) {
+      writer.uint32(8).uint32(message.code);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(18).bytes(message.data);
+    }
+    if (message.log !== '') {
+      writer.uint32(26).string(message.log);
+    }
+    if (message.info !== '') {
+      writer.uint32(34).string(message.info);
+    }
+    if (!message.gasWanted.isZero()) {
+      writer.uint32(40).int64(message.gasWanted);
+    }
+    if (!message.gasUsed.isZero()) {
+      writer.uint32(48).int64(message.gasUsed);
+    }
     for (const v of message.events) {
       Event.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    writer.uint32(66).string(message.codespace);
+    if (message.codespace !== '') {
+      writer.uint32(66).string(message.codespace);
+    }
     return writer;
   },
 
@@ -3666,6 +3773,28 @@ export const ResponseDeliverTx = {
     return message;
   },
 
+  toJSON(message: ResponseDeliverTx): unknown {
+    const obj: any = {};
+    message.code !== undefined && (obj.code = message.code);
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.log !== undefined && (obj.log = message.log);
+    message.info !== undefined && (obj.info = message.info);
+    message.gasWanted !== undefined &&
+      (obj.gasWanted = (message.gasWanted || Long.ZERO).toString());
+    message.gasUsed !== undefined &&
+      (obj.gasUsed = (message.gasUsed || Long.ZERO).toString());
+    if (message.events) {
+      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
+    } else {
+      obj.events = [];
+    }
+    message.codespace !== undefined && (obj.codespace = message.codespace);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseDeliverTx>): ResponseDeliverTx {
     const message = { ...baseResponseDeliverTx } as ResponseDeliverTx;
     message.events = [];
@@ -3711,28 +3840,6 @@ export const ResponseDeliverTx = {
     }
     return message;
   },
-
-  toJSON(message: ResponseDeliverTx): unknown {
-    const obj: any = {};
-    message.code !== undefined && (obj.code = message.code);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.log !== undefined && (obj.log = message.log);
-    message.info !== undefined && (obj.info = message.info);
-    message.gasWanted !== undefined &&
-      (obj.gasWanted = (message.gasWanted || Long.ZERO).toString());
-    message.gasUsed !== undefined &&
-      (obj.gasUsed = (message.gasUsed || Long.ZERO).toString());
-    if (message.events) {
-      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
-    } else {
-      obj.events = [];
-    }
-    message.codespace !== undefined && (obj.codespace = message.codespace);
-    return obj;
-  },
 };
 
 const baseResponseEndBlock: object = {};
@@ -3745,10 +3852,7 @@ export const ResponseEndBlock = {
     for (const v of message.validatorUpdates) {
       ValidatorUpdate.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (
-      message.consensusParamUpdates !== undefined &&
-      message.consensusParamUpdates !== undefined
-    ) {
+    if (message.consensusParamUpdates !== undefined) {
       ConsensusParams.encode(
         message.consensusParamUpdates,
         writer.uint32(18).fork()
@@ -3821,6 +3925,27 @@ export const ResponseEndBlock = {
     return message;
   },
 
+  toJSON(message: ResponseEndBlock): unknown {
+    const obj: any = {};
+    if (message.validatorUpdates) {
+      obj.validatorUpdates = message.validatorUpdates.map((e) =>
+        e ? ValidatorUpdate.toJSON(e) : undefined
+      );
+    } else {
+      obj.validatorUpdates = [];
+    }
+    message.consensusParamUpdates !== undefined &&
+      (obj.consensusParamUpdates = message.consensusParamUpdates
+        ? ConsensusParams.toJSON(message.consensusParamUpdates)
+        : undefined);
+    if (message.events) {
+      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
+    } else {
+      obj.events = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseEndBlock>): ResponseEndBlock {
     const message = { ...baseResponseEndBlock } as ResponseEndBlock;
     message.validatorUpdates = [];
@@ -3850,27 +3975,6 @@ export const ResponseEndBlock = {
     }
     return message;
   },
-
-  toJSON(message: ResponseEndBlock): unknown {
-    const obj: any = {};
-    if (message.validatorUpdates) {
-      obj.validatorUpdates = message.validatorUpdates.map((e) =>
-        e ? ValidatorUpdate.toJSON(e) : undefined
-      );
-    } else {
-      obj.validatorUpdates = [];
-    }
-    message.consensusParamUpdates !== undefined &&
-      (obj.consensusParamUpdates = message.consensusParamUpdates
-        ? ConsensusParams.toJSON(message.consensusParamUpdates)
-        : undefined);
-    if (message.events) {
-      obj.events = message.events.map((e) => (e ? Event.toJSON(e) : undefined));
-    } else {
-      obj.events = [];
-    }
-    return obj;
-  },
 };
 
 const baseResponseCommit: object = { retainHeight: Long.ZERO };
@@ -3880,8 +3984,12 @@ export const ResponseCommit = {
     message: ResponseCommit,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(18).bytes(message.data);
-    writer.uint32(24).int64(message.retainHeight);
+    if (message.data.length !== 0) {
+      writer.uint32(18).bytes(message.data);
+    }
+    if (!message.retainHeight.isZero()) {
+      writer.uint32(24).int64(message.retainHeight);
+    }
     return writer;
   },
 
@@ -3919,6 +4027,17 @@ export const ResponseCommit = {
     return message;
   },
 
+  toJSON(message: ResponseCommit): unknown {
+    const obj: any = {};
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.retainHeight !== undefined &&
+      (obj.retainHeight = (message.retainHeight || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ResponseCommit>): ResponseCommit {
     const message = { ...baseResponseCommit } as ResponseCommit;
     if (object.data !== undefined && object.data !== null) {
@@ -3932,17 +4051,6 @@ export const ResponseCommit = {
       message.retainHeight = Long.ZERO;
     }
     return message;
-  },
-
-  toJSON(message: ResponseCommit): unknown {
-    const obj: any = {};
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.retainHeight !== undefined &&
-      (obj.retainHeight = (message.retainHeight || Long.ZERO).toString());
-    return obj;
   },
 };
 
@@ -3992,6 +4100,18 @@ export const ResponseListSnapshots = {
     return message;
   },
 
+  toJSON(message: ResponseListSnapshots): unknown {
+    const obj: any = {};
+    if (message.snapshots) {
+      obj.snapshots = message.snapshots.map((e) =>
+        e ? Snapshot.toJSON(e) : undefined
+      );
+    } else {
+      obj.snapshots = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ResponseListSnapshots>
   ): ResponseListSnapshots {
@@ -4004,18 +4124,6 @@ export const ResponseListSnapshots = {
     }
     return message;
   },
-
-  toJSON(message: ResponseListSnapshots): unknown {
-    const obj: any = {};
-    if (message.snapshots) {
-      obj.snapshots = message.snapshots.map((e) =>
-        e ? Snapshot.toJSON(e) : undefined
-      );
-    } else {
-      obj.snapshots = [];
-    }
-    return obj;
-  },
 };
 
 const baseResponseOfferSnapshot: object = { result: 0 };
@@ -4025,7 +4133,9 @@ export const ResponseOfferSnapshot = {
     message: ResponseOfferSnapshot,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.result);
+    if (message.result !== 0) {
+      writer.uint32(8).int32(message.result);
+    }
     return writer;
   },
 
@@ -4060,6 +4170,13 @@ export const ResponseOfferSnapshot = {
     return message;
   },
 
+  toJSON(message: ResponseOfferSnapshot): unknown {
+    const obj: any = {};
+    message.result !== undefined &&
+      (obj.result = responseOfferSnapshot_ResultToJSON(message.result));
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ResponseOfferSnapshot>
   ): ResponseOfferSnapshot {
@@ -4071,13 +4188,6 @@ export const ResponseOfferSnapshot = {
     }
     return message;
   },
-
-  toJSON(message: ResponseOfferSnapshot): unknown {
-    const obj: any = {};
-    message.result !== undefined &&
-      (obj.result = responseOfferSnapshot_ResultToJSON(message.result));
-    return obj;
-  },
 };
 
 const baseResponseLoadSnapshotChunk: object = {};
@@ -4087,7 +4197,9 @@ export const ResponseLoadSnapshotChunk = {
     message: ResponseLoadSnapshotChunk,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.chunk);
+    if (message.chunk.length !== 0) {
+      writer.uint32(10).bytes(message.chunk);
+    }
     return writer;
   },
 
@@ -4124,6 +4236,15 @@ export const ResponseLoadSnapshotChunk = {
     return message;
   },
 
+  toJSON(message: ResponseLoadSnapshotChunk): unknown {
+    const obj: any = {};
+    message.chunk !== undefined &&
+      (obj.chunk = base64FromBytes(
+        message.chunk !== undefined ? message.chunk : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ResponseLoadSnapshotChunk>
   ): ResponseLoadSnapshotChunk {
@@ -4136,15 +4257,6 @@ export const ResponseLoadSnapshotChunk = {
       message.chunk = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: ResponseLoadSnapshotChunk): unknown {
-    const obj: any = {};
-    message.chunk !== undefined &&
-      (obj.chunk = base64FromBytes(
-        message.chunk !== undefined ? message.chunk : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -4159,7 +4271,9 @@ export const ResponseApplySnapshotChunk = {
     message: ResponseApplySnapshotChunk,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.result);
+    if (message.result !== 0) {
+      writer.uint32(8).int32(message.result);
+    }
     writer.uint32(18).fork();
     for (const v of message.refetchChunks) {
       writer.uint32(v);
@@ -4233,6 +4347,23 @@ export const ResponseApplySnapshotChunk = {
     return message;
   },
 
+  toJSON(message: ResponseApplySnapshotChunk): unknown {
+    const obj: any = {};
+    message.result !== undefined &&
+      (obj.result = responseApplySnapshotChunk_ResultToJSON(message.result));
+    if (message.refetchChunks) {
+      obj.refetchChunks = message.refetchChunks.map((e) => e);
+    } else {
+      obj.refetchChunks = [];
+    }
+    if (message.rejectSenders) {
+      obj.rejectSenders = message.rejectSenders.map((e) => e);
+    } else {
+      obj.rejectSenders = [];
+    }
+    return obj;
+  },
+
   fromPartial(
     object: DeepPartial<ResponseApplySnapshotChunk>
   ): ResponseApplySnapshotChunk {
@@ -4258,23 +4389,6 @@ export const ResponseApplySnapshotChunk = {
     }
     return message;
   },
-
-  toJSON(message: ResponseApplySnapshotChunk): unknown {
-    const obj: any = {};
-    message.result !== undefined &&
-      (obj.result = responseApplySnapshotChunk_ResultToJSON(message.result));
-    if (message.refetchChunks) {
-      obj.refetchChunks = message.refetchChunks.map((e) => e);
-    } else {
-      obj.refetchChunks = [];
-    }
-    if (message.rejectSenders) {
-      obj.rejectSenders = message.rejectSenders.map((e) => e);
-    } else {
-      obj.rejectSenders = [];
-    }
-    return obj;
-  },
 };
 
 const baseConsensusParams: object = {};
@@ -4284,22 +4398,22 @@ export const ConsensusParams = {
     message: ConsensusParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.block !== undefined && message.block !== undefined) {
+    if (message.block !== undefined) {
       BlockParams.encode(message.block, writer.uint32(10).fork()).ldelim();
     }
-    if (message.evidence !== undefined && message.evidence !== undefined) {
+    if (message.evidence !== undefined) {
       EvidenceParams.encode(
         message.evidence,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.validator !== undefined && message.validator !== undefined) {
+    if (message.validator !== undefined) {
       ValidatorParams.encode(
         message.validator,
         writer.uint32(26).fork()
       ).ldelim();
     }
-    if (message.version !== undefined && message.version !== undefined) {
+    if (message.version !== undefined) {
       VersionParams.encode(message.version, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -4357,6 +4471,27 @@ export const ConsensusParams = {
     return message;
   },
 
+  toJSON(message: ConsensusParams): unknown {
+    const obj: any = {};
+    message.block !== undefined &&
+      (obj.block = message.block
+        ? BlockParams.toJSON(message.block)
+        : undefined);
+    message.evidence !== undefined &&
+      (obj.evidence = message.evidence
+        ? EvidenceParams.toJSON(message.evidence)
+        : undefined);
+    message.validator !== undefined &&
+      (obj.validator = message.validator
+        ? ValidatorParams.toJSON(message.validator)
+        : undefined);
+    message.version !== undefined &&
+      (obj.version = message.version
+        ? VersionParams.toJSON(message.version)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConsensusParams>): ConsensusParams {
     const message = { ...baseConsensusParams } as ConsensusParams;
     if (object.block !== undefined && object.block !== null) {
@@ -4381,27 +4516,6 @@ export const ConsensusParams = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusParams): unknown {
-    const obj: any = {};
-    message.block !== undefined &&
-      (obj.block = message.block
-        ? BlockParams.toJSON(message.block)
-        : undefined);
-    message.evidence !== undefined &&
-      (obj.evidence = message.evidence
-        ? EvidenceParams.toJSON(message.evidence)
-        : undefined);
-    message.validator !== undefined &&
-      (obj.validator = message.validator
-        ? ValidatorParams.toJSON(message.validator)
-        : undefined);
-    message.version !== undefined &&
-      (obj.version = message.version
-        ? VersionParams.toJSON(message.version)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseBlockParams: object = { maxBytes: Long.ZERO, maxGas: Long.ZERO };
@@ -4411,8 +4525,12 @@ export const BlockParams = {
     message: BlockParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.maxBytes);
-    writer.uint32(16).int64(message.maxGas);
+    if (!message.maxBytes.isZero()) {
+      writer.uint32(8).int64(message.maxBytes);
+    }
+    if (!message.maxGas.isZero()) {
+      writer.uint32(16).int64(message.maxGas);
+    }
     return writer;
   },
 
@@ -4452,6 +4570,15 @@ export const BlockParams = {
     return message;
   },
 
+  toJSON(message: BlockParams): unknown {
+    const obj: any = {};
+    message.maxBytes !== undefined &&
+      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
+    message.maxGas !== undefined &&
+      (obj.maxGas = (message.maxGas || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BlockParams>): BlockParams {
     const message = { ...baseBlockParams } as BlockParams;
     if (object.maxBytes !== undefined && object.maxBytes !== null) {
@@ -4466,15 +4593,6 @@ export const BlockParams = {
     }
     return message;
   },
-
-  toJSON(message: BlockParams): unknown {
-    const obj: any = {};
-    message.maxBytes !== undefined &&
-      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
-    message.maxGas !== undefined &&
-      (obj.maxGas = (message.maxGas || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseLastCommitInfo: object = { round: 0 };
@@ -4484,7 +4602,9 @@ export const LastCommitInfo = {
     message: LastCommitInfo,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.round);
+    if (message.round !== 0) {
+      writer.uint32(8).int32(message.round);
+    }
     for (const v of message.votes) {
       VoteInfo.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -4529,6 +4649,19 @@ export const LastCommitInfo = {
     return message;
   },
 
+  toJSON(message: LastCommitInfo): unknown {
+    const obj: any = {};
+    message.round !== undefined && (obj.round = message.round);
+    if (message.votes) {
+      obj.votes = message.votes.map((e) =>
+        e ? VoteInfo.toJSON(e) : undefined
+      );
+    } else {
+      obj.votes = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<LastCommitInfo>): LastCommitInfo {
     const message = { ...baseLastCommitInfo } as LastCommitInfo;
     message.votes = [];
@@ -4544,26 +4677,15 @@ export const LastCommitInfo = {
     }
     return message;
   },
-
-  toJSON(message: LastCommitInfo): unknown {
-    const obj: any = {};
-    message.round !== undefined && (obj.round = message.round);
-    if (message.votes) {
-      obj.votes = message.votes.map((e) =>
-        e ? VoteInfo.toJSON(e) : undefined
-      );
-    } else {
-      obj.votes = [];
-    }
-    return obj;
-  },
 };
 
 const baseEvent: object = { type: '' };
 
 export const Event = {
   encode(message: Event, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).string(message.type);
+    if (message.type !== '') {
+      writer.uint32(10).string(message.type);
+    }
     for (const v of message.attributes) {
       EventAttribute.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -4610,6 +4732,19 @@ export const Event = {
     return message;
   },
 
+  toJSON(message: Event): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = message.type);
+    if (message.attributes) {
+      obj.attributes = message.attributes.map((e) =>
+        e ? EventAttribute.toJSON(e) : undefined
+      );
+    } else {
+      obj.attributes = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Event>): Event {
     const message = { ...baseEvent } as Event;
     message.attributes = [];
@@ -4625,19 +4760,6 @@ export const Event = {
     }
     return message;
   },
-
-  toJSON(message: Event): unknown {
-    const obj: any = {};
-    message.type !== undefined && (obj.type = message.type);
-    if (message.attributes) {
-      obj.attributes = message.attributes.map((e) =>
-        e ? EventAttribute.toJSON(e) : undefined
-      );
-    } else {
-      obj.attributes = [];
-    }
-    return obj;
-  },
 };
 
 const baseEventAttribute: object = { index: false };
@@ -4647,9 +4769,15 @@ export const EventAttribute = {
     message: EventAttribute,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    writer.uint32(18).bytes(message.value);
-    writer.uint32(24).bool(message.index);
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.value.length !== 0) {
+      writer.uint32(18).bytes(message.value);
+    }
+    if (message.index === true) {
+      writer.uint32(24).bool(message.index);
+    }
     return writer;
   },
 
@@ -4693,6 +4821,20 @@ export const EventAttribute = {
     return message;
   },
 
+  toJSON(message: EventAttribute): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.value !== undefined &&
+      (obj.value = base64FromBytes(
+        message.value !== undefined ? message.value : new Uint8Array()
+      ));
+    message.index !== undefined && (obj.index = message.index);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<EventAttribute>): EventAttribute {
     const message = { ...baseEventAttribute } as EventAttribute;
     if (object.key !== undefined && object.key !== null) {
@@ -4712,20 +4854,6 @@ export const EventAttribute = {
     }
     return message;
   },
-
-  toJSON(message: EventAttribute): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(
-        message.value !== undefined ? message.value : new Uint8Array()
-      ));
-    message.index !== undefined && (obj.index = message.index);
-    return obj;
-  },
 };
 
 const baseTxResult: object = { height: Long.ZERO, index: 0 };
@@ -4735,10 +4863,16 @@ export const TxResult = {
     message: TxResult,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.height);
-    writer.uint32(16).uint32(message.index);
-    writer.uint32(26).bytes(message.tx);
-    if (message.result !== undefined && message.result !== undefined) {
+    if (!message.height.isZero()) {
+      writer.uint32(8).int64(message.height);
+    }
+    if (message.index !== 0) {
+      writer.uint32(16).uint32(message.index);
+    }
+    if (message.tx.length !== 0) {
+      writer.uint32(26).bytes(message.tx);
+    }
+    if (message.result !== undefined) {
       ResponseDeliverTx.encode(
         message.result,
         writer.uint32(34).fork()
@@ -4797,6 +4931,22 @@ export const TxResult = {
     return message;
   },
 
+  toJSON(message: TxResult): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.index !== undefined && (obj.index = message.index);
+    message.tx !== undefined &&
+      (obj.tx = base64FromBytes(
+        message.tx !== undefined ? message.tx : new Uint8Array()
+      ));
+    message.result !== undefined &&
+      (obj.result = message.result
+        ? ResponseDeliverTx.toJSON(message.result)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<TxResult>): TxResult {
     const message = { ...baseTxResult } as TxResult;
     if (object.height !== undefined && object.height !== null) {
@@ -4821,22 +4971,6 @@ export const TxResult = {
     }
     return message;
   },
-
-  toJSON(message: TxResult): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.index !== undefined && (obj.index = message.index);
-    message.tx !== undefined &&
-      (obj.tx = base64FromBytes(
-        message.tx !== undefined ? message.tx : new Uint8Array()
-      ));
-    message.result !== undefined &&
-      (obj.result = message.result
-        ? ResponseDeliverTx.toJSON(message.result)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseValidator: object = { power: Long.ZERO };
@@ -4846,8 +4980,12 @@ export const Validator = {
     message: Validator,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.address);
-    writer.uint32(24).int64(message.power);
+    if (message.address.length !== 0) {
+      writer.uint32(10).bytes(message.address);
+    }
+    if (!message.power.isZero()) {
+      writer.uint32(24).int64(message.power);
+    }
     return writer;
   },
 
@@ -4885,6 +5023,17 @@ export const Validator = {
     return message;
   },
 
+  toJSON(message: Validator): unknown {
+    const obj: any = {};
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(
+        message.address !== undefined ? message.address : new Uint8Array()
+      ));
+    message.power !== undefined &&
+      (obj.power = (message.power || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Validator>): Validator {
     const message = { ...baseValidator } as Validator;
     if (object.address !== undefined && object.address !== null) {
@@ -4899,17 +5048,6 @@ export const Validator = {
     }
     return message;
   },
-
-  toJSON(message: Validator): unknown {
-    const obj: any = {};
-    message.address !== undefined &&
-      (obj.address = base64FromBytes(
-        message.address !== undefined ? message.address : new Uint8Array()
-      ));
-    message.power !== undefined &&
-      (obj.power = (message.power || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseValidatorUpdate: object = { power: Long.ZERO };
@@ -4919,10 +5057,12 @@ export const ValidatorUpdate = {
     message: ValidatorUpdate,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pubKey !== undefined && message.pubKey !== undefined) {
+    if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(16).int64(message.power);
+    if (!message.power.isZero()) {
+      writer.uint32(16).int64(message.power);
+    }
     return writer;
   },
 
@@ -4962,6 +5102,17 @@ export const ValidatorUpdate = {
     return message;
   },
 
+  toJSON(message: ValidatorUpdate): unknown {
+    const obj: any = {};
+    message.pubKey !== undefined &&
+      (obj.pubKey = message.pubKey
+        ? PublicKey.toJSON(message.pubKey)
+        : undefined);
+    message.power !== undefined &&
+      (obj.power = (message.power || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ValidatorUpdate>): ValidatorUpdate {
     const message = { ...baseValidatorUpdate } as ValidatorUpdate;
     if (object.pubKey !== undefined && object.pubKey !== null) {
@@ -4976,17 +5127,6 @@ export const ValidatorUpdate = {
     }
     return message;
   },
-
-  toJSON(message: ValidatorUpdate): unknown {
-    const obj: any = {};
-    message.pubKey !== undefined &&
-      (obj.pubKey = message.pubKey
-        ? PublicKey.toJSON(message.pubKey)
-        : undefined);
-    message.power !== undefined &&
-      (obj.power = (message.power || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseVoteInfo: object = { signedLastBlock: false };
@@ -4996,10 +5136,12 @@ export const VoteInfo = {
     message: VoteInfo,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.validator !== undefined && message.validator !== undefined) {
+    if (message.validator !== undefined) {
       Validator.encode(message.validator, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(16).bool(message.signedLastBlock);
+    if (message.signedLastBlock === true) {
+      writer.uint32(16).bool(message.signedLastBlock);
+    }
     return writer;
   },
 
@@ -5042,6 +5184,17 @@ export const VoteInfo = {
     return message;
   },
 
+  toJSON(message: VoteInfo): unknown {
+    const obj: any = {};
+    message.validator !== undefined &&
+      (obj.validator = message.validator
+        ? Validator.toJSON(message.validator)
+        : undefined);
+    message.signedLastBlock !== undefined &&
+      (obj.signedLastBlock = message.signedLastBlock);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<VoteInfo>): VoteInfo {
     const message = { ...baseVoteInfo } as VoteInfo;
     if (object.validator !== undefined && object.validator !== null) {
@@ -5059,17 +5212,6 @@ export const VoteInfo = {
     }
     return message;
   },
-
-  toJSON(message: VoteInfo): unknown {
-    const obj: any = {};
-    message.validator !== undefined &&
-      (obj.validator = message.validator
-        ? Validator.toJSON(message.validator)
-        : undefined);
-    message.signedLastBlock !== undefined &&
-      (obj.signedLastBlock = message.signedLastBlock);
-    return obj;
-  },
 };
 
 const baseEvidence: object = {
@@ -5083,15 +5225,21 @@ export const Evidence = {
     message: Evidence,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.type);
-    if (message.validator !== undefined && message.validator !== undefined) {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (message.validator !== undefined) {
       Validator.encode(message.validator, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).int64(message.height);
-    if (message.time !== undefined && message.time !== undefined) {
+    if (!message.height.isZero()) {
+      writer.uint32(24).int64(message.height);
+    }
+    if (message.time !== undefined) {
       Timestamp.encode(message.time, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(40).int64(message.totalVotingPower);
+    if (!message.totalVotingPower.isZero()) {
+      writer.uint32(40).int64(message.totalVotingPower);
+    }
     return writer;
   },
 
@@ -5158,6 +5306,27 @@ export const Evidence = {
     return message;
   },
 
+  toJSON(message: Evidence): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = evidenceTypeToJSON(message.type));
+    message.validator !== undefined &&
+      (obj.validator = message.validator
+        ? Validator.toJSON(message.validator)
+        : undefined);
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.time !== undefined &&
+      (obj.time =
+        message.time !== undefined
+          ? fromTimestamp(message.time).toISOString()
+          : null);
+    message.totalVotingPower !== undefined &&
+      (obj.totalVotingPower = (
+        message.totalVotingPower || Long.ZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Evidence>): Evidence {
     const message = { ...baseEvidence } as Evidence;
     if (object.type !== undefined && object.type !== null) {
@@ -5190,27 +5359,6 @@ export const Evidence = {
     }
     return message;
   },
-
-  toJSON(message: Evidence): unknown {
-    const obj: any = {};
-    message.type !== undefined && (obj.type = evidenceTypeToJSON(message.type));
-    message.validator !== undefined &&
-      (obj.validator = message.validator
-        ? Validator.toJSON(message.validator)
-        : undefined);
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.time !== undefined &&
-      (obj.time =
-        message.time !== undefined
-          ? fromTimestamp(message.time).toISOString()
-          : null);
-    message.totalVotingPower !== undefined &&
-      (obj.totalVotingPower = (
-        message.totalVotingPower || Long.ZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const baseSnapshot: object = { height: Long.UZERO, format: 0, chunks: 0 };
@@ -5220,11 +5368,21 @@ export const Snapshot = {
     message: Snapshot,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.height);
-    writer.uint32(16).uint32(message.format);
-    writer.uint32(24).uint32(message.chunks);
-    writer.uint32(34).bytes(message.hash);
-    writer.uint32(42).bytes(message.metadata);
+    if (!message.height.isZero()) {
+      writer.uint32(8).uint64(message.height);
+    }
+    if (message.format !== 0) {
+      writer.uint32(16).uint32(message.format);
+    }
+    if (message.chunks !== 0) {
+      writer.uint32(24).uint32(message.chunks);
+    }
+    if (message.hash.length !== 0) {
+      writer.uint32(34).bytes(message.hash);
+    }
+    if (message.metadata.length !== 0) {
+      writer.uint32(42).bytes(message.metadata);
+    }
     return writer;
   },
 
@@ -5284,6 +5442,23 @@ export const Snapshot = {
     return message;
   },
 
+  toJSON(message: Snapshot): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.UZERO).toString());
+    message.format !== undefined && (obj.format = message.format);
+    message.chunks !== undefined && (obj.chunks = message.chunks);
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(
+        message.hash !== undefined ? message.hash : new Uint8Array()
+      ));
+    message.metadata !== undefined &&
+      (obj.metadata = base64FromBytes(
+        message.metadata !== undefined ? message.metadata : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Snapshot>): Snapshot {
     const message = { ...baseSnapshot } as Snapshot;
     if (object.height !== undefined && object.height !== null) {
@@ -5312,23 +5487,6 @@ export const Snapshot = {
       message.metadata = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: Snapshot): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.UZERO).toString());
-    message.format !== undefined && (obj.format = message.format);
-    message.chunks !== undefined && (obj.chunks = message.chunks);
-    message.hash !== undefined &&
-      (obj.hash = base64FromBytes(
-        message.hash !== undefined ? message.hash : new Uint8Array()
-      ));
-    message.metadata !== undefined &&
-      (obj.metadata = base64FromBytes(
-        message.metadata !== undefined ? message.metadata : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -5547,7 +5705,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/crypto/keys.ts
+++ b/src/codec/tendermint/crypto/keys.ts
@@ -58,21 +58,6 @@ export const PublicKey = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<PublicKey>): PublicKey {
-    const message = { ...basePublicKey } as PublicKey;
-    if (object.ed25519 !== undefined && object.ed25519 !== null) {
-      message.ed25519 = object.ed25519;
-    } else {
-      message.ed25519 = undefined;
-    }
-    if (object.secp256k1 !== undefined && object.secp256k1 !== null) {
-      message.secp256k1 = object.secp256k1;
-    } else {
-      message.secp256k1 = undefined;
-    }
-    return message;
-  },
-
   toJSON(message: PublicKey): unknown {
     const obj: any = {};
     message.ed25519 !== undefined &&
@@ -87,6 +72,21 @@ export const PublicKey = {
           : undefined);
     return obj;
   },
+
+  fromPartial(object: DeepPartial<PublicKey>): PublicKey {
+    const message = { ...basePublicKey } as PublicKey;
+    if (object.ed25519 !== undefined && object.ed25519 !== null) {
+      message.ed25519 = object.ed25519;
+    } else {
+      message.ed25519 = undefined;
+    }
+    if (object.secp256k1 !== undefined && object.secp256k1 !== null) {
+      message.secp256k1 = object.secp256k1;
+    } else {
+      message.secp256k1 = undefined;
+    }
+    return message;
+  },
 };
 
 declare var self: any | undefined;
@@ -96,7 +96,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/crypto/proof.ts
+++ b/src/codec/tendermint/crypto/proof.ts
@@ -44,9 +44,15 @@ const baseProof: object = { total: Long.ZERO, index: Long.ZERO };
 
 export const Proof = {
   encode(message: Proof, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(8).int64(message.total);
-    writer.uint32(16).int64(message.index);
-    writer.uint32(26).bytes(message.leafHash);
+    if (!message.total.isZero()) {
+      writer.uint32(8).int64(message.total);
+    }
+    if (!message.index.isZero()) {
+      writer.uint32(16).int64(message.index);
+    }
+    if (message.leafHash.length !== 0) {
+      writer.uint32(26).bytes(message.leafHash);
+    }
     for (const v of message.aunts) {
       writer.uint32(34).bytes(v!);
     }
@@ -105,6 +111,26 @@ export const Proof = {
     return message;
   },
 
+  toJSON(message: Proof): unknown {
+    const obj: any = {};
+    message.total !== undefined &&
+      (obj.total = (message.total || Long.ZERO).toString());
+    message.index !== undefined &&
+      (obj.index = (message.index || Long.ZERO).toString());
+    message.leafHash !== undefined &&
+      (obj.leafHash = base64FromBytes(
+        message.leafHash !== undefined ? message.leafHash : new Uint8Array()
+      ));
+    if (message.aunts) {
+      obj.aunts = message.aunts.map((e) =>
+        base64FromBytes(e !== undefined ? e : new Uint8Array())
+      );
+    } else {
+      obj.aunts = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Proof>): Proof {
     const message = { ...baseProof } as Proof;
     message.aunts = [];
@@ -130,26 +156,6 @@ export const Proof = {
     }
     return message;
   },
-
-  toJSON(message: Proof): unknown {
-    const obj: any = {};
-    message.total !== undefined &&
-      (obj.total = (message.total || Long.ZERO).toString());
-    message.index !== undefined &&
-      (obj.index = (message.index || Long.ZERO).toString());
-    message.leafHash !== undefined &&
-      (obj.leafHash = base64FromBytes(
-        message.leafHash !== undefined ? message.leafHash : new Uint8Array()
-      ));
-    if (message.aunts) {
-      obj.aunts = message.aunts.map((e) =>
-        base64FromBytes(e !== undefined ? e : new Uint8Array())
-      );
-    } else {
-      obj.aunts = [];
-    }
-    return obj;
-  },
 };
 
 const baseValueOp: object = {};
@@ -159,8 +165,10 @@ export const ValueOp = {
     message: ValueOp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.key);
-    if (message.proof !== undefined && message.proof !== undefined) {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (message.proof !== undefined) {
       Proof.encode(message.proof, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -200,6 +208,17 @@ export const ValueOp = {
     return message;
   },
 
+  toJSON(message: ValueOp): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.proof !== undefined &&
+      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ValueOp>): ValueOp {
     const message = { ...baseValueOp } as ValueOp;
     if (object.key !== undefined && object.key !== null) {
@@ -214,17 +233,6 @@ export const ValueOp = {
     }
     return message;
   },
-
-  toJSON(message: ValueOp): unknown {
-    const obj: any = {};
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.proof !== undefined &&
-      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
-    return obj;
-  },
 };
 
 const baseDominoOp: object = { key: '', input: '', output: '' };
@@ -234,9 +242,15 @@ export const DominoOp = {
     message: DominoOp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.key);
-    writer.uint32(18).string(message.input);
-    writer.uint32(26).string(message.output);
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.input !== '') {
+      writer.uint32(18).string(message.input);
+    }
+    if (message.output !== '') {
+      writer.uint32(26).string(message.output);
+    }
     return writer;
   },
 
@@ -284,6 +298,14 @@ export const DominoOp = {
     return message;
   },
 
+  toJSON(message: DominoOp): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.input !== undefined && (obj.input = message.input);
+    message.output !== undefined && (obj.output = message.output);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<DominoOp>): DominoOp {
     const message = { ...baseDominoOp } as DominoOp;
     if (object.key !== undefined && object.key !== null) {
@@ -303,14 +325,6 @@ export const DominoOp = {
     }
     return message;
   },
-
-  toJSON(message: DominoOp): unknown {
-    const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.input !== undefined && (obj.input = message.input);
-    message.output !== undefined && (obj.output = message.output);
-    return obj;
-  },
 };
 
 const baseProofOp: object = { type: '' };
@@ -320,9 +334,15 @@ export const ProofOp = {
     message: ProofOp,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).string(message.type);
-    writer.uint32(18).bytes(message.key);
-    writer.uint32(26).bytes(message.data);
+    if (message.type !== '') {
+      writer.uint32(10).string(message.type);
+    }
+    if (message.key.length !== 0) {
+      writer.uint32(18).bytes(message.key);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(26).bytes(message.data);
+    }
     return writer;
   },
 
@@ -366,6 +386,20 @@ export const ProofOp = {
     return message;
   },
 
+  toJSON(message: ProofOp): unknown {
+    const obj: any = {};
+    message.type !== undefined && (obj.type = message.type);
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array()
+      ));
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ProofOp>): ProofOp {
     const message = { ...baseProofOp } as ProofOp;
     if (object.type !== undefined && object.type !== null) {
@@ -384,20 +418,6 @@ export const ProofOp = {
       message.data = new Uint8Array();
     }
     return message;
-  },
-
-  toJSON(message: ProofOp): unknown {
-    const obj: any = {};
-    message.type !== undefined && (obj.type = message.type);
-    message.key !== undefined &&
-      (obj.key = base64FromBytes(
-        message.key !== undefined ? message.key : new Uint8Array()
-      ));
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    return obj;
   },
 };
 
@@ -444,6 +464,16 @@ export const ProofOps = {
     return message;
   },
 
+  toJSON(message: ProofOps): unknown {
+    const obj: any = {};
+    if (message.ops) {
+      obj.ops = message.ops.map((e) => (e ? ProofOp.toJSON(e) : undefined));
+    } else {
+      obj.ops = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ProofOps>): ProofOps {
     const message = { ...baseProofOps } as ProofOps;
     message.ops = [];
@@ -454,16 +484,6 @@ export const ProofOps = {
     }
     return message;
   },
-
-  toJSON(message: ProofOps): unknown {
-    const obj: any = {};
-    if (message.ops) {
-      obj.ops = message.ops.map((e) => (e ? ProofOp.toJSON(e) : undefined));
-    } else {
-      obj.ops = [];
-    }
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -473,7 +493,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/libs/bits/types.ts
+++ b/src/codec/tendermint/libs/bits/types.ts
@@ -16,7 +16,9 @@ export const BitArray = {
     message: BitArray,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.bits);
+    if (!message.bits.isZero()) {
+      writer.uint32(8).int64(message.bits);
+    }
     writer.uint32(18).fork();
     for (const v of message.elems) {
       writer.uint64(v);
@@ -70,6 +72,18 @@ export const BitArray = {
     return message;
   },
 
+  toJSON(message: BitArray): unknown {
+    const obj: any = {};
+    message.bits !== undefined &&
+      (obj.bits = (message.bits || Long.ZERO).toString());
+    if (message.elems) {
+      obj.elems = message.elems.map((e) => (e || Long.UZERO).toString());
+    } else {
+      obj.elems = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BitArray>): BitArray {
     const message = { ...baseBitArray } as BitArray;
     message.elems = [];
@@ -84,18 +98,6 @@ export const BitArray = {
       }
     }
     return message;
-  },
-
-  toJSON(message: BitArray): unknown {
-    const obj: any = {};
-    message.bits !== undefined &&
-      (obj.bits = (message.bits || Long.ZERO).toString());
-    if (message.elems) {
-      obj.elems = message.elems.map((e) => (e || Long.UZERO).toString());
-    } else {
-      obj.elems = [];
-    }
-    return obj;
   },
 };
 

--- a/src/codec/tendermint/types/params.ts
+++ b/src/codec/tendermint/types/params.ts
@@ -92,22 +92,22 @@ export const ConsensusParams = {
     message: ConsensusParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.block !== undefined && message.block !== undefined) {
+    if (message.block !== undefined) {
       BlockParams.encode(message.block, writer.uint32(10).fork()).ldelim();
     }
-    if (message.evidence !== undefined && message.evidence !== undefined) {
+    if (message.evidence !== undefined) {
       EvidenceParams.encode(
         message.evidence,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    if (message.validator !== undefined && message.validator !== undefined) {
+    if (message.validator !== undefined) {
       ValidatorParams.encode(
         message.validator,
         writer.uint32(26).fork()
       ).ldelim();
     }
-    if (message.version !== undefined && message.version !== undefined) {
+    if (message.version !== undefined) {
       VersionParams.encode(message.version, writer.uint32(34).fork()).ldelim();
     }
     return writer;
@@ -165,6 +165,27 @@ export const ConsensusParams = {
     return message;
   },
 
+  toJSON(message: ConsensusParams): unknown {
+    const obj: any = {};
+    message.block !== undefined &&
+      (obj.block = message.block
+        ? BlockParams.toJSON(message.block)
+        : undefined);
+    message.evidence !== undefined &&
+      (obj.evidence = message.evidence
+        ? EvidenceParams.toJSON(message.evidence)
+        : undefined);
+    message.validator !== undefined &&
+      (obj.validator = message.validator
+        ? ValidatorParams.toJSON(message.validator)
+        : undefined);
+    message.version !== undefined &&
+      (obj.version = message.version
+        ? VersionParams.toJSON(message.version)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ConsensusParams>): ConsensusParams {
     const message = { ...baseConsensusParams } as ConsensusParams;
     if (object.block !== undefined && object.block !== null) {
@@ -189,27 +210,6 @@ export const ConsensusParams = {
     }
     return message;
   },
-
-  toJSON(message: ConsensusParams): unknown {
-    const obj: any = {};
-    message.block !== undefined &&
-      (obj.block = message.block
-        ? BlockParams.toJSON(message.block)
-        : undefined);
-    message.evidence !== undefined &&
-      (obj.evidence = message.evidence
-        ? EvidenceParams.toJSON(message.evidence)
-        : undefined);
-    message.validator !== undefined &&
-      (obj.validator = message.validator
-        ? ValidatorParams.toJSON(message.validator)
-        : undefined);
-    message.version !== undefined &&
-      (obj.version = message.version
-        ? VersionParams.toJSON(message.version)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseBlockParams: object = {
@@ -223,9 +223,15 @@ export const BlockParams = {
     message: BlockParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.maxBytes);
-    writer.uint32(16).int64(message.maxGas);
-    writer.uint32(24).int64(message.timeIotaMs);
+    if (!message.maxBytes.isZero()) {
+      writer.uint32(8).int64(message.maxBytes);
+    }
+    if (!message.maxGas.isZero()) {
+      writer.uint32(16).int64(message.maxGas);
+    }
+    if (!message.timeIotaMs.isZero()) {
+      writer.uint32(24).int64(message.timeIotaMs);
+    }
     return writer;
   },
 
@@ -273,6 +279,17 @@ export const BlockParams = {
     return message;
   },
 
+  toJSON(message: BlockParams): unknown {
+    const obj: any = {};
+    message.maxBytes !== undefined &&
+      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
+    message.maxGas !== undefined &&
+      (obj.maxGas = (message.maxGas || Long.ZERO).toString());
+    message.timeIotaMs !== undefined &&
+      (obj.timeIotaMs = (message.timeIotaMs || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BlockParams>): BlockParams {
     const message = { ...baseBlockParams } as BlockParams;
     if (object.maxBytes !== undefined && object.maxBytes !== null) {
@@ -292,17 +309,6 @@ export const BlockParams = {
     }
     return message;
   },
-
-  toJSON(message: BlockParams): unknown {
-    const obj: any = {};
-    message.maxBytes !== undefined &&
-      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
-    message.maxGas !== undefined &&
-      (obj.maxGas = (message.maxGas || Long.ZERO).toString());
-    message.timeIotaMs !== undefined &&
-      (obj.timeIotaMs = (message.timeIotaMs || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseEvidenceParams: object = {
@@ -315,17 +321,18 @@ export const EvidenceParams = {
     message: EvidenceParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.maxAgeNumBlocks);
-    if (
-      message.maxAgeDuration !== undefined &&
-      message.maxAgeDuration !== undefined
-    ) {
+    if (!message.maxAgeNumBlocks.isZero()) {
+      writer.uint32(8).int64(message.maxAgeNumBlocks);
+    }
+    if (message.maxAgeDuration !== undefined) {
       Duration.encode(
         message.maxAgeDuration,
         writer.uint32(18).fork()
       ).ldelim();
     }
-    writer.uint32(24).int64(message.maxBytes);
+    if (!message.maxBytes.isZero()) {
+      writer.uint32(24).int64(message.maxBytes);
+    }
     return writer;
   },
 
@@ -376,6 +383,19 @@ export const EvidenceParams = {
     return message;
   },
 
+  toJSON(message: EvidenceParams): unknown {
+    const obj: any = {};
+    message.maxAgeNumBlocks !== undefined &&
+      (obj.maxAgeNumBlocks = (message.maxAgeNumBlocks || Long.ZERO).toString());
+    message.maxAgeDuration !== undefined &&
+      (obj.maxAgeDuration = message.maxAgeDuration
+        ? Duration.toJSON(message.maxAgeDuration)
+        : undefined);
+    message.maxBytes !== undefined &&
+      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<EvidenceParams>): EvidenceParams {
     const message = { ...baseEvidenceParams } as EvidenceParams;
     if (
@@ -397,19 +417,6 @@ export const EvidenceParams = {
       message.maxBytes = Long.ZERO;
     }
     return message;
-  },
-
-  toJSON(message: EvidenceParams): unknown {
-    const obj: any = {};
-    message.maxAgeNumBlocks !== undefined &&
-      (obj.maxAgeNumBlocks = (message.maxAgeNumBlocks || Long.ZERO).toString());
-    message.maxAgeDuration !== undefined &&
-      (obj.maxAgeDuration = message.maxAgeDuration
-        ? Duration.toJSON(message.maxAgeDuration)
-        : undefined);
-    message.maxBytes !== undefined &&
-      (obj.maxBytes = (message.maxBytes || Long.ZERO).toString());
-    return obj;
   },
 };
 
@@ -456,6 +463,16 @@ export const ValidatorParams = {
     return message;
   },
 
+  toJSON(message: ValidatorParams): unknown {
+    const obj: any = {};
+    if (message.pubKeyTypes) {
+      obj.pubKeyTypes = message.pubKeyTypes.map((e) => e);
+    } else {
+      obj.pubKeyTypes = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ValidatorParams>): ValidatorParams {
     const message = { ...baseValidatorParams } as ValidatorParams;
     message.pubKeyTypes = [];
@@ -466,16 +483,6 @@ export const ValidatorParams = {
     }
     return message;
   },
-
-  toJSON(message: ValidatorParams): unknown {
-    const obj: any = {};
-    if (message.pubKeyTypes) {
-      obj.pubKeyTypes = message.pubKeyTypes.map((e) => e);
-    } else {
-      obj.pubKeyTypes = [];
-    }
-    return obj;
-  },
 };
 
 const baseVersionParams: object = { appVersion: Long.UZERO };
@@ -485,7 +492,9 @@ export const VersionParams = {
     message: VersionParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.appVersion);
+    if (!message.appVersion.isZero()) {
+      writer.uint32(8).uint64(message.appVersion);
+    }
     return writer;
   },
 
@@ -517,6 +526,13 @@ export const VersionParams = {
     return message;
   },
 
+  toJSON(message: VersionParams): unknown {
+    const obj: any = {};
+    message.appVersion !== undefined &&
+      (obj.appVersion = (message.appVersion || Long.UZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<VersionParams>): VersionParams {
     const message = { ...baseVersionParams } as VersionParams;
     if (object.appVersion !== undefined && object.appVersion !== null) {
@@ -525,13 +541,6 @@ export const VersionParams = {
       message.appVersion = Long.UZERO;
     }
     return message;
-  },
-
-  toJSON(message: VersionParams): unknown {
-    const obj: any = {};
-    message.appVersion !== undefined &&
-      (obj.appVersion = (message.appVersion || Long.UZERO).toString());
-    return obj;
   },
 };
 
@@ -545,8 +554,12 @@ export const HashedParams = {
     message: HashedParams,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.blockMaxBytes);
-    writer.uint32(16).int64(message.blockMaxGas);
+    if (!message.blockMaxBytes.isZero()) {
+      writer.uint32(8).int64(message.blockMaxBytes);
+    }
+    if (!message.blockMaxGas.isZero()) {
+      writer.uint32(16).int64(message.blockMaxGas);
+    }
     return writer;
   },
 
@@ -586,6 +599,15 @@ export const HashedParams = {
     return message;
   },
 
+  toJSON(message: HashedParams): unknown {
+    const obj: any = {};
+    message.blockMaxBytes !== undefined &&
+      (obj.blockMaxBytes = (message.blockMaxBytes || Long.ZERO).toString());
+    message.blockMaxGas !== undefined &&
+      (obj.blockMaxGas = (message.blockMaxGas || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<HashedParams>): HashedParams {
     const message = { ...baseHashedParams } as HashedParams;
     if (object.blockMaxBytes !== undefined && object.blockMaxBytes !== null) {
@@ -599,15 +621,6 @@ export const HashedParams = {
       message.blockMaxGas = Long.ZERO;
     }
     return message;
-  },
-
-  toJSON(message: HashedParams): unknown {
-    const obj: any = {};
-    message.blockMaxBytes !== undefined &&
-      (obj.blockMaxBytes = (message.blockMaxBytes || Long.ZERO).toString());
-    message.blockMaxGas !== undefined &&
-      (obj.blockMaxGas = (message.blockMaxGas || Long.ZERO).toString());
-    return obj;
   },
 };
 

--- a/src/codec/tendermint/types/types.ts
+++ b/src/codec/tendermint/types/types.ts
@@ -230,8 +230,12 @@ export const PartSetHeader = {
     message: PartSetHeader,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint32(message.total);
-    writer.uint32(18).bytes(message.hash);
+    if (message.total !== 0) {
+      writer.uint32(8).uint32(message.total);
+    }
+    if (message.hash.length !== 0) {
+      writer.uint32(18).bytes(message.hash);
+    }
     return writer;
   },
 
@@ -269,6 +273,16 @@ export const PartSetHeader = {
     return message;
   },
 
+  toJSON(message: PartSetHeader): unknown {
+    const obj: any = {};
+    message.total !== undefined && (obj.total = message.total);
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(
+        message.hash !== undefined ? message.hash : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<PartSetHeader>): PartSetHeader {
     const message = { ...basePartSetHeader } as PartSetHeader;
     if (object.total !== undefined && object.total !== null) {
@@ -283,25 +297,19 @@ export const PartSetHeader = {
     }
     return message;
   },
-
-  toJSON(message: PartSetHeader): unknown {
-    const obj: any = {};
-    message.total !== undefined && (obj.total = message.total);
-    message.hash !== undefined &&
-      (obj.hash = base64FromBytes(
-        message.hash !== undefined ? message.hash : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const basePart: object = { index: 0 };
 
 export const Part = {
   encode(message: Part, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(8).uint32(message.index);
-    writer.uint32(18).bytes(message.bytes);
-    if (message.proof !== undefined && message.proof !== undefined) {
+    if (message.index !== 0) {
+      writer.uint32(8).uint32(message.index);
+    }
+    if (message.bytes.length !== 0) {
+      writer.uint32(18).bytes(message.bytes);
+    }
+    if (message.proof !== undefined) {
       Proof.encode(message.proof, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -349,6 +357,18 @@ export const Part = {
     return message;
   },
 
+  toJSON(message: Part): unknown {
+    const obj: any = {};
+    message.index !== undefined && (obj.index = message.index);
+    message.bytes !== undefined &&
+      (obj.bytes = base64FromBytes(
+        message.bytes !== undefined ? message.bytes : new Uint8Array()
+      ));
+    message.proof !== undefined &&
+      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Part>): Part {
     const message = { ...basePart } as Part;
     if (object.index !== undefined && object.index !== null) {
@@ -368,18 +388,6 @@ export const Part = {
     }
     return message;
   },
-
-  toJSON(message: Part): unknown {
-    const obj: any = {};
-    message.index !== undefined && (obj.index = message.index);
-    message.bytes !== undefined &&
-      (obj.bytes = base64FromBytes(
-        message.bytes !== undefined ? message.bytes : new Uint8Array()
-      ));
-    message.proof !== undefined &&
-      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
-    return obj;
-  },
 };
 
 const baseBlockID: object = {};
@@ -389,11 +397,10 @@ export const BlockID = {
     message: BlockID,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.hash);
-    if (
-      message.partSetHeader !== undefined &&
-      message.partSetHeader !== undefined
-    ) {
+    if (message.hash.length !== 0) {
+      writer.uint32(10).bytes(message.hash);
+    }
+    if (message.partSetHeader !== undefined) {
       PartSetHeader.encode(
         message.partSetHeader,
         writer.uint32(18).fork()
@@ -436,6 +443,19 @@ export const BlockID = {
     return message;
   },
 
+  toJSON(message: BlockID): unknown {
+    const obj: any = {};
+    message.hash !== undefined &&
+      (obj.hash = base64FromBytes(
+        message.hash !== undefined ? message.hash : new Uint8Array()
+      ));
+    message.partSetHeader !== undefined &&
+      (obj.partSetHeader = message.partSetHeader
+        ? PartSetHeader.toJSON(message.partSetHeader)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BlockID>): BlockID {
     const message = { ...baseBlockID } as BlockID;
     if (object.hash !== undefined && object.hash !== null) {
@@ -450,19 +470,6 @@ export const BlockID = {
     }
     return message;
   },
-
-  toJSON(message: BlockID): unknown {
-    const obj: any = {};
-    message.hash !== undefined &&
-      (obj.hash = base64FromBytes(
-        message.hash !== undefined ? message.hash : new Uint8Array()
-      ));
-    message.partSetHeader !== undefined &&
-      (obj.partSetHeader = message.partSetHeader
-        ? PartSetHeader.toJSON(message.partSetHeader)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseHeader: object = { chainId: '', height: Long.ZERO };
@@ -472,29 +479,48 @@ export const Header = {
     message: Header,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.version !== undefined && message.version !== undefined) {
+    if (message.version !== undefined) {
       Consensus.encode(message.version, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(18).string(message.chainId);
-    writer.uint32(24).int64(message.height);
-    if (message.time !== undefined && message.time !== undefined) {
+    if (message.chainId !== '') {
+      writer.uint32(18).string(message.chainId);
+    }
+    if (!message.height.isZero()) {
+      writer.uint32(24).int64(message.height);
+    }
+    if (message.time !== undefined) {
       Timestamp.encode(message.time, writer.uint32(34).fork()).ldelim();
     }
-    if (
-      message.lastBlockId !== undefined &&
-      message.lastBlockId !== undefined
-    ) {
+    if (message.lastBlockId !== undefined) {
       BlockID.encode(message.lastBlockId, writer.uint32(42).fork()).ldelim();
     }
-    writer.uint32(50).bytes(message.lastCommitHash);
-    writer.uint32(58).bytes(message.dataHash);
-    writer.uint32(66).bytes(message.validatorsHash);
-    writer.uint32(74).bytes(message.nextValidatorsHash);
-    writer.uint32(82).bytes(message.consensusHash);
-    writer.uint32(90).bytes(message.appHash);
-    writer.uint32(98).bytes(message.lastResultsHash);
-    writer.uint32(106).bytes(message.evidenceHash);
-    writer.uint32(114).bytes(message.proposerAddress);
+    if (message.lastCommitHash.length !== 0) {
+      writer.uint32(50).bytes(message.lastCommitHash);
+    }
+    if (message.dataHash.length !== 0) {
+      writer.uint32(58).bytes(message.dataHash);
+    }
+    if (message.validatorsHash.length !== 0) {
+      writer.uint32(66).bytes(message.validatorsHash);
+    }
+    if (message.nextValidatorsHash.length !== 0) {
+      writer.uint32(74).bytes(message.nextValidatorsHash);
+    }
+    if (message.consensusHash.length !== 0) {
+      writer.uint32(82).bytes(message.consensusHash);
+    }
+    if (message.appHash.length !== 0) {
+      writer.uint32(90).bytes(message.appHash);
+    }
+    if (message.lastResultsHash.length !== 0) {
+      writer.uint32(98).bytes(message.lastResultsHash);
+    }
+    if (message.evidenceHash.length !== 0) {
+      writer.uint32(106).bytes(message.evidenceHash);
+    }
+    if (message.proposerAddress.length !== 0) {
+      writer.uint32(114).bytes(message.proposerAddress);
+    }
     return writer;
   },
 
@@ -621,6 +647,77 @@ export const Header = {
     return message;
   },
 
+  toJSON(message: Header): unknown {
+    const obj: any = {};
+    message.version !== undefined &&
+      (obj.version = message.version
+        ? Consensus.toJSON(message.version)
+        : undefined);
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.time !== undefined &&
+      (obj.time =
+        message.time !== undefined
+          ? fromTimestamp(message.time).toISOString()
+          : null);
+    message.lastBlockId !== undefined &&
+      (obj.lastBlockId = message.lastBlockId
+        ? BlockID.toJSON(message.lastBlockId)
+        : undefined);
+    message.lastCommitHash !== undefined &&
+      (obj.lastCommitHash = base64FromBytes(
+        message.lastCommitHash !== undefined
+          ? message.lastCommitHash
+          : new Uint8Array()
+      ));
+    message.dataHash !== undefined &&
+      (obj.dataHash = base64FromBytes(
+        message.dataHash !== undefined ? message.dataHash : new Uint8Array()
+      ));
+    message.validatorsHash !== undefined &&
+      (obj.validatorsHash = base64FromBytes(
+        message.validatorsHash !== undefined
+          ? message.validatorsHash
+          : new Uint8Array()
+      ));
+    message.nextValidatorsHash !== undefined &&
+      (obj.nextValidatorsHash = base64FromBytes(
+        message.nextValidatorsHash !== undefined
+          ? message.nextValidatorsHash
+          : new Uint8Array()
+      ));
+    message.consensusHash !== undefined &&
+      (obj.consensusHash = base64FromBytes(
+        message.consensusHash !== undefined
+          ? message.consensusHash
+          : new Uint8Array()
+      ));
+    message.appHash !== undefined &&
+      (obj.appHash = base64FromBytes(
+        message.appHash !== undefined ? message.appHash : new Uint8Array()
+      ));
+    message.lastResultsHash !== undefined &&
+      (obj.lastResultsHash = base64FromBytes(
+        message.lastResultsHash !== undefined
+          ? message.lastResultsHash
+          : new Uint8Array()
+      ));
+    message.evidenceHash !== undefined &&
+      (obj.evidenceHash = base64FromBytes(
+        message.evidenceHash !== undefined
+          ? message.evidenceHash
+          : new Uint8Array()
+      ));
+    message.proposerAddress !== undefined &&
+      (obj.proposerAddress = base64FromBytes(
+        message.proposerAddress !== undefined
+          ? message.proposerAddress
+          : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Header>): Header {
     const message = { ...baseHeader } as Header;
     if (object.version !== undefined && object.version !== null) {
@@ -704,77 +801,6 @@ export const Header = {
     }
     return message;
   },
-
-  toJSON(message: Header): unknown {
-    const obj: any = {};
-    message.version !== undefined &&
-      (obj.version = message.version
-        ? Consensus.toJSON(message.version)
-        : undefined);
-    message.chainId !== undefined && (obj.chainId = message.chainId);
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.time !== undefined &&
-      (obj.time =
-        message.time !== undefined
-          ? fromTimestamp(message.time).toISOString()
-          : null);
-    message.lastBlockId !== undefined &&
-      (obj.lastBlockId = message.lastBlockId
-        ? BlockID.toJSON(message.lastBlockId)
-        : undefined);
-    message.lastCommitHash !== undefined &&
-      (obj.lastCommitHash = base64FromBytes(
-        message.lastCommitHash !== undefined
-          ? message.lastCommitHash
-          : new Uint8Array()
-      ));
-    message.dataHash !== undefined &&
-      (obj.dataHash = base64FromBytes(
-        message.dataHash !== undefined ? message.dataHash : new Uint8Array()
-      ));
-    message.validatorsHash !== undefined &&
-      (obj.validatorsHash = base64FromBytes(
-        message.validatorsHash !== undefined
-          ? message.validatorsHash
-          : new Uint8Array()
-      ));
-    message.nextValidatorsHash !== undefined &&
-      (obj.nextValidatorsHash = base64FromBytes(
-        message.nextValidatorsHash !== undefined
-          ? message.nextValidatorsHash
-          : new Uint8Array()
-      ));
-    message.consensusHash !== undefined &&
-      (obj.consensusHash = base64FromBytes(
-        message.consensusHash !== undefined
-          ? message.consensusHash
-          : new Uint8Array()
-      ));
-    message.appHash !== undefined &&
-      (obj.appHash = base64FromBytes(
-        message.appHash !== undefined ? message.appHash : new Uint8Array()
-      ));
-    message.lastResultsHash !== undefined &&
-      (obj.lastResultsHash = base64FromBytes(
-        message.lastResultsHash !== undefined
-          ? message.lastResultsHash
-          : new Uint8Array()
-      ));
-    message.evidenceHash !== undefined &&
-      (obj.evidenceHash = base64FromBytes(
-        message.evidenceHash !== undefined
-          ? message.evidenceHash
-          : new Uint8Array()
-      ));
-    message.proposerAddress !== undefined &&
-      (obj.proposerAddress = base64FromBytes(
-        message.proposerAddress !== undefined
-          ? message.proposerAddress
-          : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseData: object = {};
@@ -817,17 +843,6 @@ export const Data = {
     return message;
   },
 
-  fromPartial(object: DeepPartial<Data>): Data {
-    const message = { ...baseData } as Data;
-    message.txs = [];
-    if (object.txs !== undefined && object.txs !== null) {
-      for (const e of object.txs) {
-        message.txs.push(e);
-      }
-    }
-    return message;
-  },
-
   toJSON(message: Data): unknown {
     const obj: any = {};
     if (message.txs) {
@@ -838,6 +853,17 @@ export const Data = {
       obj.txs = [];
     }
     return obj;
+  },
+
+  fromPartial(object: DeepPartial<Data>): Data {
+    const message = { ...baseData } as Data;
+    message.txs = [];
+    if (object.txs !== undefined && object.txs !== null) {
+      for (const e of object.txs) {
+        message.txs.push(e);
+      }
+    }
+    return message;
   },
 };
 
@@ -850,18 +876,30 @@ const baseVote: object = {
 
 export const Vote = {
   encode(message: Vote, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(8).int32(message.type);
-    writer.uint32(16).int64(message.height);
-    writer.uint32(24).int32(message.round);
-    if (message.blockId !== undefined && message.blockId !== undefined) {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (!message.height.isZero()) {
+      writer.uint32(16).int64(message.height);
+    }
+    if (message.round !== 0) {
+      writer.uint32(24).int32(message.round);
+    }
+    if (message.blockId !== undefined) {
       BlockID.encode(message.blockId, writer.uint32(34).fork()).ldelim();
     }
-    if (message.timestamp !== undefined && message.timestamp !== undefined) {
+    if (message.timestamp !== undefined) {
       Timestamp.encode(message.timestamp, writer.uint32(42).fork()).ldelim();
     }
-    writer.uint32(50).bytes(message.validatorAddress);
-    writer.uint32(56).int32(message.validatorIndex);
-    writer.uint32(66).bytes(message.signature);
+    if (message.validatorAddress.length !== 0) {
+      writer.uint32(50).bytes(message.validatorAddress);
+    }
+    if (message.validatorIndex !== 0) {
+      writer.uint32(56).int32(message.validatorIndex);
+    }
+    if (message.signature.length !== 0) {
+      writer.uint32(66).bytes(message.signature);
+    }
     return writer;
   },
 
@@ -948,6 +986,37 @@ export const Vote = {
     return message;
   },
 
+  toJSON(message: Vote): unknown {
+    const obj: any = {};
+    message.type !== undefined &&
+      (obj.type = signedMsgTypeToJSON(message.type));
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.round !== undefined && (obj.round = message.round);
+    message.blockId !== undefined &&
+      (obj.blockId = message.blockId
+        ? BlockID.toJSON(message.blockId)
+        : undefined);
+    message.timestamp !== undefined &&
+      (obj.timestamp =
+        message.timestamp !== undefined
+          ? fromTimestamp(message.timestamp).toISOString()
+          : null);
+    message.validatorAddress !== undefined &&
+      (obj.validatorAddress = base64FromBytes(
+        message.validatorAddress !== undefined
+          ? message.validatorAddress
+          : new Uint8Array()
+      ));
+    message.validatorIndex !== undefined &&
+      (obj.validatorIndex = message.validatorIndex);
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(
+        message.signature !== undefined ? message.signature : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Vote>): Vote {
     const message = { ...baseVote } as Vote;
     if (object.type !== undefined && object.type !== null) {
@@ -995,37 +1064,6 @@ export const Vote = {
     }
     return message;
   },
-
-  toJSON(message: Vote): unknown {
-    const obj: any = {};
-    message.type !== undefined &&
-      (obj.type = signedMsgTypeToJSON(message.type));
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.round !== undefined && (obj.round = message.round);
-    message.blockId !== undefined &&
-      (obj.blockId = message.blockId
-        ? BlockID.toJSON(message.blockId)
-        : undefined);
-    message.timestamp !== undefined &&
-      (obj.timestamp =
-        message.timestamp !== undefined
-          ? fromTimestamp(message.timestamp).toISOString()
-          : null);
-    message.validatorAddress !== undefined &&
-      (obj.validatorAddress = base64FromBytes(
-        message.validatorAddress !== undefined
-          ? message.validatorAddress
-          : new Uint8Array()
-      ));
-    message.validatorIndex !== undefined &&
-      (obj.validatorIndex = message.validatorIndex);
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(
-        message.signature !== undefined ? message.signature : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseCommit: object = { height: Long.ZERO, round: 0 };
@@ -1035,9 +1073,13 @@ export const Commit = {
     message: Commit,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int64(message.height);
-    writer.uint32(16).int32(message.round);
-    if (message.blockId !== undefined && message.blockId !== undefined) {
+    if (!message.height.isZero()) {
+      writer.uint32(8).int64(message.height);
+    }
+    if (message.round !== 0) {
+      writer.uint32(16).int32(message.round);
+    }
+    if (message.blockId !== undefined) {
       BlockID.encode(message.blockId, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.signatures) {
@@ -1100,6 +1142,25 @@ export const Commit = {
     return message;
   },
 
+  toJSON(message: Commit): unknown {
+    const obj: any = {};
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.round !== undefined && (obj.round = message.round);
+    message.blockId !== undefined &&
+      (obj.blockId = message.blockId
+        ? BlockID.toJSON(message.blockId)
+        : undefined);
+    if (message.signatures) {
+      obj.signatures = message.signatures.map((e) =>
+        e ? CommitSig.toJSON(e) : undefined
+      );
+    } else {
+      obj.signatures = [];
+    }
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Commit>): Commit {
     const message = { ...baseCommit } as Commit;
     message.signatures = [];
@@ -1125,25 +1186,6 @@ export const Commit = {
     }
     return message;
   },
-
-  toJSON(message: Commit): unknown {
-    const obj: any = {};
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.round !== undefined && (obj.round = message.round);
-    message.blockId !== undefined &&
-      (obj.blockId = message.blockId
-        ? BlockID.toJSON(message.blockId)
-        : undefined);
-    if (message.signatures) {
-      obj.signatures = message.signatures.map((e) =>
-        e ? CommitSig.toJSON(e) : undefined
-      );
-    } else {
-      obj.signatures = [];
-    }
-    return obj;
-  },
 };
 
 const baseCommitSig: object = { blockIdFlag: 0 };
@@ -1153,12 +1195,18 @@ export const CommitSig = {
     message: CommitSig,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.blockIdFlag);
-    writer.uint32(18).bytes(message.validatorAddress);
-    if (message.timestamp !== undefined && message.timestamp !== undefined) {
+    if (message.blockIdFlag !== 0) {
+      writer.uint32(8).int32(message.blockIdFlag);
+    }
+    if (message.validatorAddress.length !== 0) {
+      writer.uint32(18).bytes(message.validatorAddress);
+    }
+    if (message.timestamp !== undefined) {
       Timestamp.encode(message.timestamp, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(34).bytes(message.signature);
+    if (message.signature.length !== 0) {
+      writer.uint32(34).bytes(message.signature);
+    }
     return writer;
   },
 
@@ -1213,6 +1261,28 @@ export const CommitSig = {
     return message;
   },
 
+  toJSON(message: CommitSig): unknown {
+    const obj: any = {};
+    message.blockIdFlag !== undefined &&
+      (obj.blockIdFlag = blockIDFlagToJSON(message.blockIdFlag));
+    message.validatorAddress !== undefined &&
+      (obj.validatorAddress = base64FromBytes(
+        message.validatorAddress !== undefined
+          ? message.validatorAddress
+          : new Uint8Array()
+      ));
+    message.timestamp !== undefined &&
+      (obj.timestamp =
+        message.timestamp !== undefined
+          ? fromTimestamp(message.timestamp).toISOString()
+          : null);
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(
+        message.signature !== undefined ? message.signature : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<CommitSig>): CommitSig {
     const message = { ...baseCommitSig } as CommitSig;
     if (object.blockIdFlag !== undefined && object.blockIdFlag !== null) {
@@ -1240,28 +1310,6 @@ export const CommitSig = {
     }
     return message;
   },
-
-  toJSON(message: CommitSig): unknown {
-    const obj: any = {};
-    message.blockIdFlag !== undefined &&
-      (obj.blockIdFlag = blockIDFlagToJSON(message.blockIdFlag));
-    message.validatorAddress !== undefined &&
-      (obj.validatorAddress = base64FromBytes(
-        message.validatorAddress !== undefined
-          ? message.validatorAddress
-          : new Uint8Array()
-      ));
-    message.timestamp !== undefined &&
-      (obj.timestamp =
-        message.timestamp !== undefined
-          ? fromTimestamp(message.timestamp).toISOString()
-          : null);
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(
-        message.signature !== undefined ? message.signature : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseProposal: object = {
@@ -1276,17 +1324,27 @@ export const Proposal = {
     message: Proposal,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).int32(message.type);
-    writer.uint32(16).int64(message.height);
-    writer.uint32(24).int32(message.round);
-    writer.uint32(32).int32(message.polRound);
-    if (message.blockId !== undefined && message.blockId !== undefined) {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (!message.height.isZero()) {
+      writer.uint32(16).int64(message.height);
+    }
+    if (message.round !== 0) {
+      writer.uint32(24).int32(message.round);
+    }
+    if (message.polRound !== 0) {
+      writer.uint32(32).int32(message.polRound);
+    }
+    if (message.blockId !== undefined) {
       BlockID.encode(message.blockId, writer.uint32(42).fork()).ldelim();
     }
-    if (message.timestamp !== undefined && message.timestamp !== undefined) {
+    if (message.timestamp !== undefined) {
       Timestamp.encode(message.timestamp, writer.uint32(50).fork()).ldelim();
     }
-    writer.uint32(58).bytes(message.signature);
+    if (message.signature.length !== 0) {
+      writer.uint32(58).bytes(message.signature);
+    }
     return writer;
   },
 
@@ -1364,6 +1422,30 @@ export const Proposal = {
     return message;
   },
 
+  toJSON(message: Proposal): unknown {
+    const obj: any = {};
+    message.type !== undefined &&
+      (obj.type = signedMsgTypeToJSON(message.type));
+    message.height !== undefined &&
+      (obj.height = (message.height || Long.ZERO).toString());
+    message.round !== undefined && (obj.round = message.round);
+    message.polRound !== undefined && (obj.polRound = message.polRound);
+    message.blockId !== undefined &&
+      (obj.blockId = message.blockId
+        ? BlockID.toJSON(message.blockId)
+        : undefined);
+    message.timestamp !== undefined &&
+      (obj.timestamp =
+        message.timestamp !== undefined
+          ? fromTimestamp(message.timestamp).toISOString()
+          : null);
+    message.signature !== undefined &&
+      (obj.signature = base64FromBytes(
+        message.signature !== undefined ? message.signature : new Uint8Array()
+      ));
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Proposal>): Proposal {
     const message = { ...baseProposal } as Proposal;
     if (object.type !== undefined && object.type !== null) {
@@ -1403,30 +1485,6 @@ export const Proposal = {
     }
     return message;
   },
-
-  toJSON(message: Proposal): unknown {
-    const obj: any = {};
-    message.type !== undefined &&
-      (obj.type = signedMsgTypeToJSON(message.type));
-    message.height !== undefined &&
-      (obj.height = (message.height || Long.ZERO).toString());
-    message.round !== undefined && (obj.round = message.round);
-    message.polRound !== undefined && (obj.polRound = message.polRound);
-    message.blockId !== undefined &&
-      (obj.blockId = message.blockId
-        ? BlockID.toJSON(message.blockId)
-        : undefined);
-    message.timestamp !== undefined &&
-      (obj.timestamp =
-        message.timestamp !== undefined
-          ? fromTimestamp(message.timestamp).toISOString()
-          : null);
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(
-        message.signature !== undefined ? message.signature : new Uint8Array()
-      ));
-    return obj;
-  },
 };
 
 const baseSignedHeader: object = {};
@@ -1436,10 +1494,10 @@ export const SignedHeader = {
     message: SignedHeader,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.header !== undefined && message.header !== undefined) {
+    if (message.header !== undefined) {
       Header.encode(message.header, writer.uint32(10).fork()).ldelim();
     }
-    if (message.commit !== undefined && message.commit !== undefined) {
+    if (message.commit !== undefined) {
       Commit.encode(message.commit, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1481,6 +1539,15 @@ export const SignedHeader = {
     return message;
   },
 
+  toJSON(message: SignedHeader): unknown {
+    const obj: any = {};
+    message.header !== undefined &&
+      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
+    message.commit !== undefined &&
+      (obj.commit = message.commit ? Commit.toJSON(message.commit) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<SignedHeader>): SignedHeader {
     const message = { ...baseSignedHeader } as SignedHeader;
     if (object.header !== undefined && object.header !== null) {
@@ -1495,15 +1562,6 @@ export const SignedHeader = {
     }
     return message;
   },
-
-  toJSON(message: SignedHeader): unknown {
-    const obj: any = {};
-    message.header !== undefined &&
-      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
-    message.commit !== undefined &&
-      (obj.commit = message.commit ? Commit.toJSON(message.commit) : undefined);
-    return obj;
-  },
 };
 
 const baseLightBlock: object = {};
@@ -1513,19 +1571,13 @@ export const LightBlock = {
     message: LightBlock,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (
-      message.signedHeader !== undefined &&
-      message.signedHeader !== undefined
-    ) {
+    if (message.signedHeader !== undefined) {
       SignedHeader.encode(
         message.signedHeader,
         writer.uint32(10).fork()
       ).ldelim();
     }
-    if (
-      message.validatorSet !== undefined &&
-      message.validatorSet !== undefined
-    ) {
+    if (message.validatorSet !== undefined) {
       ValidatorSet.encode(
         message.validatorSet,
         writer.uint32(18).fork()
@@ -1570,6 +1622,19 @@ export const LightBlock = {
     return message;
   },
 
+  toJSON(message: LightBlock): unknown {
+    const obj: any = {};
+    message.signedHeader !== undefined &&
+      (obj.signedHeader = message.signedHeader
+        ? SignedHeader.toJSON(message.signedHeader)
+        : undefined);
+    message.validatorSet !== undefined &&
+      (obj.validatorSet = message.validatorSet
+        ? ValidatorSet.toJSON(message.validatorSet)
+        : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<LightBlock>): LightBlock {
     const message = { ...baseLightBlock } as LightBlock;
     if (object.signedHeader !== undefined && object.signedHeader !== null) {
@@ -1584,19 +1649,6 @@ export const LightBlock = {
     }
     return message;
   },
-
-  toJSON(message: LightBlock): unknown {
-    const obj: any = {};
-    message.signedHeader !== undefined &&
-      (obj.signedHeader = message.signedHeader
-        ? SignedHeader.toJSON(message.signedHeader)
-        : undefined);
-    message.validatorSet !== undefined &&
-      (obj.validatorSet = message.validatorSet
-        ? ValidatorSet.toJSON(message.validatorSet)
-        : undefined);
-    return obj;
-  },
 };
 
 const baseBlockMeta: object = { blockSize: Long.ZERO, numTxs: Long.ZERO };
@@ -1606,14 +1658,18 @@ export const BlockMeta = {
     message: BlockMeta,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.blockId !== undefined && message.blockId !== undefined) {
+    if (message.blockId !== undefined) {
       BlockID.encode(message.blockId, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(16).int64(message.blockSize);
-    if (message.header !== undefined && message.header !== undefined) {
+    if (!message.blockSize.isZero()) {
+      writer.uint32(16).int64(message.blockSize);
+    }
+    if (message.header !== undefined) {
       Header.encode(message.header, writer.uint32(26).fork()).ldelim();
     }
-    writer.uint32(32).int64(message.numTxs);
+    if (!message.numTxs.isZero()) {
+      writer.uint32(32).int64(message.numTxs);
+    }
     return writer;
   },
 
@@ -1669,6 +1725,21 @@ export const BlockMeta = {
     return message;
   },
 
+  toJSON(message: BlockMeta): unknown {
+    const obj: any = {};
+    message.blockId !== undefined &&
+      (obj.blockId = message.blockId
+        ? BlockID.toJSON(message.blockId)
+        : undefined);
+    message.blockSize !== undefined &&
+      (obj.blockSize = (message.blockSize || Long.ZERO).toString());
+    message.header !== undefined &&
+      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
+    message.numTxs !== undefined &&
+      (obj.numTxs = (message.numTxs || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<BlockMeta>): BlockMeta {
     const message = { ...baseBlockMeta } as BlockMeta;
     if (object.blockId !== undefined && object.blockId !== null) {
@@ -1693,21 +1764,6 @@ export const BlockMeta = {
     }
     return message;
   },
-
-  toJSON(message: BlockMeta): unknown {
-    const obj: any = {};
-    message.blockId !== undefined &&
-      (obj.blockId = message.blockId
-        ? BlockID.toJSON(message.blockId)
-        : undefined);
-    message.blockSize !== undefined &&
-      (obj.blockSize = (message.blockSize || Long.ZERO).toString());
-    message.header !== undefined &&
-      (obj.header = message.header ? Header.toJSON(message.header) : undefined);
-    message.numTxs !== undefined &&
-      (obj.numTxs = (message.numTxs || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 const baseTxProof: object = {};
@@ -1717,9 +1773,13 @@ export const TxProof = {
     message: TxProof,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.rootHash);
-    writer.uint32(18).bytes(message.data);
-    if (message.proof !== undefined && message.proof !== undefined) {
+    if (message.rootHash.length !== 0) {
+      writer.uint32(10).bytes(message.rootHash);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(18).bytes(message.data);
+    }
+    if (message.proof !== undefined) {
       Proof.encode(message.proof, writer.uint32(26).fork()).ldelim();
     }
     return writer;
@@ -1765,6 +1825,21 @@ export const TxProof = {
     return message;
   },
 
+  toJSON(message: TxProof): unknown {
+    const obj: any = {};
+    message.rootHash !== undefined &&
+      (obj.rootHash = base64FromBytes(
+        message.rootHash !== undefined ? message.rootHash : new Uint8Array()
+      ));
+    message.data !== undefined &&
+      (obj.data = base64FromBytes(
+        message.data !== undefined ? message.data : new Uint8Array()
+      ));
+    message.proof !== undefined &&
+      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<TxProof>): TxProof {
     const message = { ...baseTxProof } as TxProof;
     if (object.rootHash !== undefined && object.rootHash !== null) {
@@ -1784,21 +1859,6 @@ export const TxProof = {
     }
     return message;
   },
-
-  toJSON(message: TxProof): unknown {
-    const obj: any = {};
-    message.rootHash !== undefined &&
-      (obj.rootHash = base64FromBytes(
-        message.rootHash !== undefined ? message.rootHash : new Uint8Array()
-      ));
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
-    message.proof !== undefined &&
-      (obj.proof = message.proof ? Proof.toJSON(message.proof) : undefined);
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -1808,7 +1868,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/types/validator.ts
+++ b/src/codec/tendermint/types/validator.ts
@@ -33,10 +33,12 @@ export const ValidatorSet = {
     for (const v of message.validators) {
       Validator.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.proposer !== undefined && message.proposer !== undefined) {
+    if (message.proposer !== undefined) {
       Validator.encode(message.proposer, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).int64(message.totalVotingPower);
+    if (!message.totalVotingPower.isZero()) {
+      writer.uint32(24).int64(message.totalVotingPower);
+    }
     return writer;
   },
 
@@ -89,6 +91,26 @@ export const ValidatorSet = {
     return message;
   },
 
+  toJSON(message: ValidatorSet): unknown {
+    const obj: any = {};
+    if (message.validators) {
+      obj.validators = message.validators.map((e) =>
+        e ? Validator.toJSON(e) : undefined
+      );
+    } else {
+      obj.validators = [];
+    }
+    message.proposer !== undefined &&
+      (obj.proposer = message.proposer
+        ? Validator.toJSON(message.proposer)
+        : undefined);
+    message.totalVotingPower !== undefined &&
+      (obj.totalVotingPower = (
+        message.totalVotingPower || Long.ZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<ValidatorSet>): ValidatorSet {
     const message = { ...baseValidatorSet } as ValidatorSet;
     message.validators = [];
@@ -112,26 +134,6 @@ export const ValidatorSet = {
     }
     return message;
   },
-
-  toJSON(message: ValidatorSet): unknown {
-    const obj: any = {};
-    if (message.validators) {
-      obj.validators = message.validators.map((e) =>
-        e ? Validator.toJSON(e) : undefined
-      );
-    } else {
-      obj.validators = [];
-    }
-    message.proposer !== undefined &&
-      (obj.proposer = message.proposer
-        ? Validator.toJSON(message.proposer)
-        : undefined);
-    message.totalVotingPower !== undefined &&
-      (obj.totalVotingPower = (
-        message.totalVotingPower || Long.ZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const baseValidator: object = {
@@ -144,12 +146,18 @@ export const Validator = {
     message: Validator,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(10).bytes(message.address);
-    if (message.pubKey !== undefined && message.pubKey !== undefined) {
+    if (message.address.length !== 0) {
+      writer.uint32(10).bytes(message.address);
+    }
+    if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(24).int64(message.votingPower);
-    writer.uint32(32).int64(message.proposerPriority);
+    if (!message.votingPower.isZero()) {
+      writer.uint32(24).int64(message.votingPower);
+    }
+    if (!message.proposerPriority.isZero()) {
+      writer.uint32(32).int64(message.proposerPriority);
+    }
     return writer;
   },
 
@@ -206,6 +214,25 @@ export const Validator = {
     return message;
   },
 
+  toJSON(message: Validator): unknown {
+    const obj: any = {};
+    message.address !== undefined &&
+      (obj.address = base64FromBytes(
+        message.address !== undefined ? message.address : new Uint8Array()
+      ));
+    message.pubKey !== undefined &&
+      (obj.pubKey = message.pubKey
+        ? PublicKey.toJSON(message.pubKey)
+        : undefined);
+    message.votingPower !== undefined &&
+      (obj.votingPower = (message.votingPower || Long.ZERO).toString());
+    message.proposerPriority !== undefined &&
+      (obj.proposerPriority = (
+        message.proposerPriority || Long.ZERO
+      ).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<Validator>): Validator {
     const message = { ...baseValidator } as Validator;
     if (object.address !== undefined && object.address !== null) {
@@ -233,25 +260,6 @@ export const Validator = {
     }
     return message;
   },
-
-  toJSON(message: Validator): unknown {
-    const obj: any = {};
-    message.address !== undefined &&
-      (obj.address = base64FromBytes(
-        message.address !== undefined ? message.address : new Uint8Array()
-      ));
-    message.pubKey !== undefined &&
-      (obj.pubKey = message.pubKey
-        ? PublicKey.toJSON(message.pubKey)
-        : undefined);
-    message.votingPower !== undefined &&
-      (obj.votingPower = (message.votingPower || Long.ZERO).toString());
-    message.proposerPriority !== undefined &&
-      (obj.proposerPriority = (
-        message.proposerPriority || Long.ZERO
-      ).toString());
-    return obj;
-  },
 };
 
 const baseSimpleValidator: object = { votingPower: Long.ZERO };
@@ -261,10 +269,12 @@ export const SimpleValidator = {
     message: SimpleValidator,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.pubKey !== undefined && message.pubKey !== undefined) {
+    if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(10).fork()).ldelim();
     }
-    writer.uint32(16).int64(message.votingPower);
+    if (!message.votingPower.isZero()) {
+      writer.uint32(16).int64(message.votingPower);
+    }
     return writer;
   },
 
@@ -304,6 +314,17 @@ export const SimpleValidator = {
     return message;
   },
 
+  toJSON(message: SimpleValidator): unknown {
+    const obj: any = {};
+    message.pubKey !== undefined &&
+      (obj.pubKey = message.pubKey
+        ? PublicKey.toJSON(message.pubKey)
+        : undefined);
+    message.votingPower !== undefined &&
+      (obj.votingPower = (message.votingPower || Long.ZERO).toString());
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<SimpleValidator>): SimpleValidator {
     const message = { ...baseSimpleValidator } as SimpleValidator;
     if (object.pubKey !== undefined && object.pubKey !== null) {
@@ -318,17 +339,6 @@ export const SimpleValidator = {
     }
     return message;
   },
-
-  toJSON(message: SimpleValidator): unknown {
-    const obj: any = {};
-    message.pubKey !== undefined &&
-      (obj.pubKey = message.pubKey
-        ? PublicKey.toJSON(message.pubKey)
-        : undefined);
-    message.votingPower !== undefined &&
-      (obj.votingPower = (message.votingPower || Long.ZERO).toString());
-    return obj;
-  },
 };
 
 declare var self: any | undefined;
@@ -338,7 +348,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =

--- a/src/codec/tendermint/version/types.ts
+++ b/src/codec/tendermint/version/types.ts
@@ -15,20 +15,25 @@ export interface App {
 }
 
 /**
- * Consensus captures the consensus rules for processing a block in the
- * blockchain, including all blockchain data structures and the rules of the
- * application's state transition machine.
+ * Consensus captures the consensus rules for processing a block in the blockchain,
+ * including all blockchain data structures and the rules of the application's
+ * state transition machine.
  */
 export interface Consensus {
   block: Long;
+  app: Long;
 }
 
 const baseApp: object = { protocol: Long.UZERO, software: '' };
 
 export const App = {
   encode(message: App, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(8).uint64(message.protocol);
-    writer.uint32(18).string(message.software);
+    if (!message.protocol.isZero()) {
+      writer.uint32(8).uint64(message.protocol);
+    }
+    if (message.software !== '') {
+      writer.uint32(18).string(message.software);
+    }
     return writer;
   },
 
@@ -68,6 +73,14 @@ export const App = {
     return message;
   },
 
+  toJSON(message: App): unknown {
+    const obj: any = {};
+    message.protocol !== undefined &&
+      (obj.protocol = (message.protocol || Long.UZERO).toString());
+    message.software !== undefined && (obj.software = message.software);
+    return obj;
+  },
+
   fromPartial(object: DeepPartial<App>): App {
     const message = { ...baseApp } as App;
     if (object.protocol !== undefined && object.protocol !== null) {
@@ -82,24 +95,21 @@ export const App = {
     }
     return message;
   },
-
-  toJSON(message: App): unknown {
-    const obj: any = {};
-    message.protocol !== undefined &&
-      (obj.protocol = (message.protocol || Long.UZERO).toString());
-    message.software !== undefined && (obj.software = message.software);
-    return obj;
-  },
 };
 
-const baseConsensus: object = { block: Long.UZERO };
+const baseConsensus: object = { block: Long.UZERO, app: Long.UZERO };
 
 export const Consensus = {
   encode(
     message: Consensus,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    writer.uint32(8).uint64(message.block);
+    if (!message.block.isZero()) {
+      writer.uint32(8).uint64(message.block);
+    }
+    if (!message.app.isZero()) {
+      writer.uint32(16).uint64(message.app);
+    }
     return writer;
   },
 
@@ -112,6 +122,9 @@ export const Consensus = {
       switch (tag >>> 3) {
         case 1:
           message.block = reader.uint64() as Long;
+          break;
+        case 2:
+          message.app = reader.uint64() as Long;
           break;
         default:
           reader.skipType(tag & 7);
@@ -128,7 +141,21 @@ export const Consensus = {
     } else {
       message.block = Long.UZERO;
     }
+    if (object.app !== undefined && object.app !== null) {
+      message.app = Long.fromString(object.app);
+    } else {
+      message.app = Long.UZERO;
+    }
     return message;
+  },
+
+  toJSON(message: Consensus): unknown {
+    const obj: any = {};
+    message.block !== undefined &&
+      (obj.block = (message.block || Long.UZERO).toString());
+    message.app !== undefined &&
+      (obj.app = (message.app || Long.UZERO).toString());
+    return obj;
   },
 
   fromPartial(object: DeepPartial<Consensus>): Consensus {
@@ -138,14 +165,12 @@ export const Consensus = {
     } else {
       message.block = Long.UZERO;
     }
+    if (object.app !== undefined && object.app !== null) {
+      message.app = object.app as Long;
+    } else {
+      message.app = Long.UZERO;
+    }
     return message;
-  },
-
-  toJSON(message: Consensus): unknown {
-    const obj: any = {};
-    message.block !== undefined &&
-      (obj.block = (message.block || Long.UZERO).toString());
-    return obj;
   },
 };
 

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -154,7 +154,7 @@ test.serial('perform connection handshake', async (t) => {
   await dest.connOpenConfirm(proofConfirm);
 });
 
-test.serial.only('transfer message and send packets', async (t) => {
+test.serial('transfer message and send packets', async (t) => {
   // set up ics20 channel
   const [nodeA, nodeB] = await setup();
   const link = await Link.createWithNewConnections(nodeA, nodeB);
@@ -166,8 +166,6 @@ test.serial.only('transfer message and send packets', async (t) => {
     ics20.version
   );
   t.is(channels.src.portId, ics20.srcPortId);
-
-  console.log('start failing test');
 
   // make an account on remote chain, and check it is empty
   const recipient = randomAddress(wasmd.prefix);
@@ -185,8 +183,6 @@ test.serial.only('transfer message and send packets', async (t) => {
     destHeight + 500 // valid for 500 blocks
   );
 
-  console.log('ics20 transfer done');
-
   const packets = parsePacketsFromLogs(transferResult.logs);
   t.is(packets.length, 1);
   const packet = packets[0];
@@ -197,15 +193,11 @@ test.serial.only('transfer message and send packets', async (t) => {
   const headerHeight = await nodeB.doUpdateClient(link.endB.clientID, nodeA);
   const proof = await nodeA.getPacketProof(packet, headerHeight);
 
-  console.log('before receive packet');
-
   const relayResult = await nodeB.receivePacket(
     packet,
     proof,
     toProtoHeight(headerHeight)
   );
-
-  console.log('after receive packet');
 
   // query balance of recipient (should be "12345" or some odd hash...)
   const postBalance = await nodeB.query.bank.unverified.allBalances(recipient);

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -154,7 +154,7 @@ test.serial('perform connection handshake', async (t) => {
   await dest.connOpenConfirm(proofConfirm);
 });
 
-test.serial('transfer message and send packets', async (t) => {
+test.serial.only('transfer message and send packets', async (t) => {
   // set up ics20 channel
   const [nodeA, nodeB] = await setup();
   const link = await Link.createWithNewConnections(nodeA, nodeB);
@@ -166,6 +166,8 @@ test.serial('transfer message and send packets', async (t) => {
     ics20.version
   );
   t.is(channels.src.portId, ics20.srcPortId);
+
+  console.log('start failing test');
 
   // make an account on remote chain, and check it is empty
   const recipient = randomAddress(wasmd.prefix);
@@ -183,6 +185,8 @@ test.serial('transfer message and send packets', async (t) => {
     destHeight + 500 // valid for 500 blocks
   );
 
+  console.log('ics20 transfer done');
+
   const packets = parsePacketsFromLogs(transferResult.logs);
   t.is(packets.length, 1);
   const packet = packets[0];
@@ -192,11 +196,16 @@ test.serial('transfer message and send packets', async (t) => {
   await nodeA.waitOneBlock();
   const headerHeight = await nodeB.doUpdateClient(link.endB.clientID, nodeA);
   const proof = await nodeA.getPacketProof(packet, headerHeight);
+
+  console.log('before receive packet');
+
   const relayResult = await nodeB.receivePacket(
     packet,
     proof,
     toProtoHeight(headerHeight)
   );
+
+  console.log('after receive packet');
 
   // query balance of recipient (should be "12345" or some odd hash...)
   const postBalance = await nodeB.query.bank.unverified.allBalances(recipient);

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -977,8 +977,6 @@ export class IbcClient {
     proofCommitments: Uint8Array[],
     proofHeight?: Height
   ): Promise<MsgResult> {
-    console.log(`proofHeight: ${proofHeight}`);
-    console.log(`isZero: ${proofHeight?.revisionNumber?.isZero()}`);
     if (packets.length !== proofCommitments.length) {
       throw new Error(
         `Have ${packets.length} packets, but ${proofCommitments.length} proofs`
@@ -1000,8 +998,6 @@ export class IbcClient {
           signer: senderAddress,
         }),
       };
-      console.log('msg');
-      console.log(msg.value.proofHeight);
       msgs.push(msg);
     }
     const result = await this.sign.signAndBroadcast(

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -977,6 +977,8 @@ export class IbcClient {
     proofCommitments: Uint8Array[],
     proofHeight?: Height
   ): Promise<MsgResult> {
+    console.log(`proofHeight: ${proofHeight}`);
+    console.log(`isZero: ${proofHeight?.revisionNumber?.isZero()}`);
     if (packets.length !== proofCommitments.length) {
       throw new Error(
         `Have ${packets.length} packets, but ${proofCommitments.length} proofs`
@@ -998,6 +1000,8 @@ export class IbcClient {
           signer: senderAddress,
         }),
       };
+      console.log('msg');
+      console.log(msg.value.proofHeight);
       msgs.push(msg);
     }
     const result = await this.sign.signAndBroadcast(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,7 @@ export function toIntHeight(height?: Height): number {
 export function toProtoHeight(height: number): Height {
   return Height.fromPartial({
     revisionHeight: new Long(height),
+    revisionNumber: new Long(0), // TODO: do we need this?
   });
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,6 +40,14 @@ export function toProtoHeight(height: number): Height {
   });
 }
 
+// may will run the transform if value is defined, otherwise returns undefined
+export function may<T, U>(
+  transform: (val: T) => U,
+  value: T | null | undefined
+): U | undefined {
+  return value === undefined || value === null ? undefined : transform(value);
+}
+
 export function mapRpcPubKeyToProto(
   pubkey?: RpcPubKey
 ): ProtoPubKey | undefined {
@@ -184,7 +192,7 @@ export function parsePacket({ type, attributes }: ParsedEvent): Packet {
   const [timeoutRevisionNumber, timeoutRevisionHeight] =
     attributesObj.packet_timeout_height?.split('-') ?? [];
   return Packet.fromPartial({
-    sequence: Long.fromString(attributesObj.packet_sequence ?? '0', true),
+    sequence: may(Long.fromString, attributesObj.packet_sequence),
     /** identifies the port on the sending chain. */
     sourcePort: attributesObj.packet_src_port,
     /** identifies the channel end on the sending chain. */
@@ -206,9 +214,9 @@ export function parsePacket({ type, attributes }: ParsedEvent): Packet {
           })
         : undefined,
     /** block timestamp (in nanoseconds) after which the packet times out */
-    timeoutTimestamp: Long.fromString(
-      attributesObj.packet_timeout_timestamp ?? '0',
-      true
+    timeoutTimestamp: may(
+      Long.fromString,
+      attributesObj.packet_timeout_timestamp
     ),
   });
 }
@@ -236,7 +244,7 @@ export function parseAck({ type, attributes }: ParsedEvent): Ack {
   const [timeoutRevisionNumber, timeoutRevisionHeight] =
     attributesObj.packet_timeout_height?.split('-') ?? [];
   const originalPacket = Packet.fromPartial({
-    sequence: Long.fromString(attributesObj.packet_sequence ?? '0', true),
+    sequence: may(Long.fromString, attributesObj.packet_sequence),
     /** identifies the port on the sending chain. */
     sourcePort: attributesObj.packet_src_port,
     /** identifies the channel end on the sending chain. */
@@ -256,9 +264,9 @@ export function parseAck({ type, attributes }: ParsedEvent): Ack {
           })
         : undefined,
     /** block timestamp (in nanoseconds) after which the packet times out */
-    timeoutTimestamp: Long.fromString(
-      attributesObj.packet_timeout_timestamp ?? '0',
-      true
+    timeoutTimestamp: may(
+      Long.fromString,
+      attributesObj.packet_timeout_timestamp
     ),
   });
   const acknowledgement = toUtf8(attributesObj.packet_ack ?? '');


### PR DESCRIPTION
Closes #64 

This has the timestamp and default fields fixes in.
Strange encoding failure.

```
transfer message and send packets

  Rejected promise returned by test. Reason:

  TypeError {
    message: 'message.revisionNumber.isZero is not a function',
  }

  › Object.encode (build/main/codec/ibc/core/client/v1/client.js:2:19514)
  › Object.encode (build/main/codec/ibc/core/channel/v1/channel.js:14:24172)
  › Object.encode (build/main/codec/ibc/core/channel/v1/tx.js:2:55363)
  › Registry.encode (node_modules/@cosmjs/proto-signing/src/registry.ts:77:33)
  › node_modules/@cosmjs/proto-signing/src/registry.ts:82:33
  › Array.map (<anonymous>)
  › Registry.encodeTxBody (node_modules/@cosmjs/proto-signing/src/registry.ts:81:51)
  › Registry.encode (node_modules/@cosmjs/proto-signing/src/registry.ts:73:19)
  › SigningStargateClient.signAndBroadcast (node_modules/@cosmjs/stargate/src/signingstargateclient.ts:155:39)
```

In this case, `message.revisionNumber` is `"0"` not `Long(0)`. (From `console.log` calls, no idea how that happened)

@webmaster128 Not sure if there are any insights from https://github.com/cosmos/cosmjs/pull/683