### PR TITLE
Relay packets

### DIFF
--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -973,8 +973,8 @@ export class IbcClient {
   }
 
   public async receivePackets(
-    packets: Packet[],
-    proofCommitments: Uint8Array[],
+    packets: readonly Packet[],
+    proofCommitments: readonly Uint8Array[],
     proofHeight?: Height
   ): Promise<MsgResult> {
     if (packets.length !== proofCommitments.length) {
@@ -1025,8 +1025,8 @@ export class IbcClient {
   }
 
   public async acknowledgePackets(
-    acks: Ack[],
-    proofAckeds: Uint8Array[],
+    acks: readonly Ack[],
+    proofAckeds: readonly Uint8Array[],
     proofHeight?: Height
   ): Promise<MsgResult> {
     if (acks.length !== proofAckeds.length) {

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -248,9 +248,9 @@ test.serial('submit multiple tx, get unreceived packets', async (t) => {
   const preAcks = await link.getPendingAcks('B');
   t.is(preAcks.length, 0);
 
-  // // let's pre-update to test conditional logic (no need to update below)
-  // await nodeA.waitOneBlock();
-  // await link.updateClient('A');
+  // let's pre-update to test conditional logic (no need to update below)
+  await nodeA.waitOneBlock();
+  await link.updateClient('A');
 
   // submit 2 of them (out of order)
   const submit = [packets[0], packets[2]];
@@ -266,8 +266,7 @@ test.serial('submit multiple tx, get unreceived packets', async (t) => {
   const acks = await link.getPendingAcks('B');
   t.is(acks.length, 2);
 
-  // submit one of the acks
-  // relay them together
+  // submit one of the acks, without waiting (it must update client)
   await link.relayAcks('B', acks.slice(0, 1));
 
   // ensure only one ack is still pending

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -4,7 +4,6 @@ import { State } from '../codec/ibc/core/channel/v1/channel';
 
 import { Link } from './link';
 import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
-import { toProtoHeight } from './utils';
 
 test.serial('establish new client-connection', async (t) => {
   const [src, dest] = await setup();
@@ -265,15 +264,7 @@ test.serial.only('submit multiple tx, get unreceived packets', async (t) => {
 
   // submit one of the acks
   // relay them together
-  await nodeB.waitOneBlock();
-  const ackHeaderHeight = await nodeA.doUpdateClient(link.endA.clientID, nodeB);
-  const ack = acks[0];
-  const ackProof = await nodeB.getAckProof(ack, ackHeaderHeight);
-  await nodeA.acknowledgePackets(
-    [ack],
-    [ackProof],
-    toProtoHeight(ackHeaderHeight)
-  );
+  await link.relayAcks('B', acks.slice(0, 1));
 
   // ensure only one ack is still pending
   const postAcks = await link.getPendingAcks('B');

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -401,10 +401,7 @@ export class Link {
     const { src, dest } = this.getEnds(source);
 
     // check if we need to update client at all
-    const maxPacketHeight = packets.reduce(
-      (acc, { height }) => Math.max(acc, height),
-      0
-    );
+    const maxPacketHeight = Math.max(...packets.map((x) => x.height));
     let headerHeight = await this.lastKnownHeader(otherSide(source));
 
     if (headerHeight < maxPacketHeight + 1) {
@@ -440,10 +437,7 @@ export class Link {
     const { src, dest } = this.getEnds(source);
 
     // check if we need to update client at all
-    const maxPacketHeight = acks.reduce(
-      (acc, { height }) => Math.max(acc, height),
-      0
-    );
+    const maxPacketHeight = Math.max(...acks.map((x) => x.height));
     let headerHeight = await this.lastKnownHeader(otherSide(source));
     if (headerHeight < maxPacketHeight + 1) {
       const curHeight = (await src.client.latestHeader()).height;


### PR DESCRIPTION
Closes #9 
Closes #10 

Based on #70 (merge that first)

This adds high-level `relayAck` and `relayPacket` helpers to Link. Along with the `queryPending{Ack,Packets}` functions and conditional updateClient usage, this provides all the components needed to easily construct a relayer process