### PR TITLE
Add logger to lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@types/sinon": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "ava": "^3.12.1",
@@ -73,6 +74,7 @@
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
+    "sinon": "^9.2.4",
     "standard-version": "^9.0.0",
     "ts-node": "^9.0.0",
     "ts-proto": "^1.67.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Endpoint } from './lib/endpoint';
 export { IbcClient } from './lib/ibcclient';
 export { Link } from './lib/link';
-export { Logger } from './lib/utils';
+export { Logger, NoopLogger } from './lib/logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Endpoint } from './lib/endpoint';
 export { IbcClient } from './lib/ibcclient';
 export { Link } from './lib/link';
+export { Logger } from './lib/utils';

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -5,7 +5,14 @@ import { MsgTransfer } from '../codec/ibc/applications/transfer/v1/tx';
 
 import { buildCreateClientArgs, prepareConnectionHandshake } from './ibcclient';
 import { Link } from './link';
-import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
+import {
+  ics20,
+  randomAddress,
+  setup,
+  simapp,
+  TestLogger,
+  wasmd,
+} from './testutils.spec';
 import {
   buildClientState,
   buildConsensusState,
@@ -15,12 +22,15 @@ import {
 } from './utils';
 
 test.serial('create simapp client on wasmd', async (t) => {
-  const [src, dest] = await setup();
+  const logger = new TestLogger();
+  const [src, dest] = await setup(logger);
 
   const preClients = await dest.query.ibc.client.allStates();
   const preLen = preClients.clientStates.length;
 
   const header = await src.latestHeader();
+  t.assert(logger.info.calledOnce, logger.info.callCount.toString());
+
   const conState = buildConsensusState(header);
   const cliState = buildClientState(
     await src.getChainId(),
@@ -155,9 +165,10 @@ test.serial('perform connection handshake', async (t) => {
 });
 
 test.serial('transfer message and send packets', async (t) => {
+  const logger = new TestLogger();
   // set up ics20 channel
   const [nodeA, nodeB] = await setup();
-  const link = await Link.createWithNewConnections(nodeA, nodeB);
+  const link = await Link.createWithNewConnections(nodeA, nodeB, logger);
   const channels = await link.createChannel(
     'A',
     ics20.srcPortId,
@@ -220,9 +231,10 @@ test.serial('transfer message and send packets', async (t) => {
 });
 
 test.serial('tests parsing with multi-message', async (t) => {
+  const logger = new TestLogger();
   // set up ics20 channel
   const [nodeA, nodeB] = await setup();
-  const link = await Link.createWithNewConnections(nodeA, nodeB);
+  const link = await Link.createWithNewConnections(nodeA, nodeB, logger);
   const channels = await link.createChannel(
     'A',
     ics20.srcPortId,

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -233,7 +233,7 @@ test.serial('transfer message and send packets', async (t) => {
 test.serial('tests parsing with multi-message', async (t) => {
   const logger = new TestLogger();
   // set up ics20 channel
-  const [nodeA, nodeB] = await setup();
+  const [nodeA, nodeB] = await setup(logger);
   const link = await Link.createWithNewConnections(nodeA, nodeB, logger);
   const channels = await link.createChannel(
     'A',
@@ -251,6 +251,15 @@ test.serial('tests parsing with multi-message', async (t) => {
   const { logs: sendLogs } = await nodeA.sendTokens(srcAddr, [
     { amount: '5000', denom: simapp.denomFee },
   ]);
+  t.assert(
+    logger.verbose.calledWithMatch(/Send tokens to/),
+    logger.verbose.callCount.toString()
+  );
+  t.assert(
+    logger.debug.calledWithMatch(/Send tokens:/),
+    logger.debug.callCount.toString()
+  );
+
   const sendPackets = parsePacketsFromLogs(sendLogs);
   t.is(sendPackets.length, 0);
 

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -29,7 +29,7 @@ test.serial('create simapp client on wasmd', async (t) => {
   const preLen = preClients.clientStates.length;
 
   const header = await src.latestHeader();
-  t.assert(logger.info.calledOnce, logger.info.callCount.toString());
+  t.assert(logger.verbose.calledOnce, logger.verbose.callCount.toString());
 
   const conState = buildConsensusState(header);
   const cliState = buildClientState(

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -263,7 +263,7 @@ export class IbcClient {
   }
 
   public async latestHeader(): Promise<RpcHeader> {
-    this.logger.info('Getting latest header');
+    this.logger.verbose('Get latest header');
     // TODO: expose header method on tmClient and use that
     const block = await this.tm.block();
     return block.block.header;
@@ -512,6 +512,13 @@ export class IbcClient {
     transferAmount: readonly Coin[],
     memo?: string
   ): Promise<MsgResult> {
+    this.logger.verbose(`Send tokens to ${recipientAddress}`);
+    this.logger.debug('Send tokens:', {
+      senderAddress: this.senderAddress,
+      recipientAddress,
+      transferAmount,
+      memo,
+    });
     const result = await this.sign.sendTokens(
       this.senderAddress,
       recipientAddress,
@@ -806,6 +813,7 @@ export class IbcClient {
     connectionId: string,
     version: string
   ): Promise<CreateChannelResult> {
+    this.logger.verbose('Channel Open Init');
     const senderAddress = this.senderAddress;
     const msg = {
       typeUrl: '/ibc.core.channel.v1.MsgChannelOpenInit',
@@ -823,6 +831,7 @@ export class IbcClient {
         signer: senderAddress,
       }),
     };
+    this.logger.debug('MsgChannelOpenInit', msg);
 
     const result = await this.sign.signAndBroadcast(
       senderAddress,

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -67,13 +67,13 @@ import {
 } from '../codec/tendermint/types/types';
 import { ValidatorSet } from '../codec/tendermint/types/validator';
 
+import { Logger, NoopLogger } from './logger';
 import { IbcExtension, setupIbcExtension } from './queries/ibc';
 import {
   Ack,
   buildClientState,
   buildConsensusState,
   createBroadcastTxErrorMessage,
-  Logger,
   mapRpcPubKeyToProto,
   multiplyFees,
   timestampFromDateNanos,
@@ -212,7 +212,7 @@ export class IbcClient {
     IbcExtension;
   public readonly tm: TendermintClient;
   public readonly senderAddress: string;
-  public readonly logger?: Logger;
+  public readonly logger: Logger;
 
   public static async connectWithSigner(
     endpoint: string,
@@ -255,7 +255,7 @@ export class IbcClient {
       defaultGasLimits,
       gasLimits
     );
-    this.logger = logger;
+    this.logger = logger ?? new NoopLogger();
   }
 
   public getChainId(): Promise<string> {
@@ -263,7 +263,7 @@ export class IbcClient {
   }
 
   public async latestHeader(): Promise<RpcHeader> {
-    this.logger?.info('Getting latest header');
+    this.logger.info('Getting latest header');
     // TODO: expose header method on tmClient and use that
     const block = await this.tm.block();
     return block.block.header;

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -4,12 +4,20 @@ import test from 'ava';
 import { State } from '../codec/ibc/core/channel/v1/channel';
 
 import { Link } from './link';
-import { ics20, randomAddress, setup, simapp, wasmd } from './testutils.spec';
+import {
+  ics20,
+  randomAddress,
+  setup,
+  simapp,
+  TestLogger,
+  wasmd,
+} from './testutils.spec';
 
 test.serial('establish new client-connection', async (t) => {
+  const logger = new TestLogger();
   const [src, dest] = await setup();
 
-  const link = await Link.createWithNewConnections(src, dest);
+  const link = await Link.createWithNewConnections(src, dest, logger);
   // ensure the data makes sense (TODO: more?)
   t.assert(link.endA.clientID.startsWith('07-tendermint-'), link.endA.clientID);
   t.assert(link.endB.clientID.startsWith('07-tendermint-'), link.endB.clientID);
@@ -19,6 +27,8 @@ test.serial('establish new client-connection', async (t) => {
   // TODO: ensure it is updated
   await link.updateClient('B');
   // TODO: ensure it is updated
+
+  t.assert(logger.info.calledTwice, logger.info.callCount.toString());
 });
 
 test.serial('initialized connection and start channel handshake', async (t) => {

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -15,7 +15,8 @@ import {
   prepareChannelHandshake,
   prepareConnectionHandshake,
 } from './ibcclient';
-import { Logger, parseAcksFromLogs, toIntHeight, toProtoHeight } from './utils';
+import { Logger, NoopLogger } from './logger';
+import { parseAcksFromLogs, toIntHeight, toProtoHeight } from './utils';
 
 /**
  * Many actions on link focus on a src and a dest. Rather than add two functions,
@@ -46,7 +47,7 @@ const genesisUnbondingTime = 1814400;
 export class Link {
   public readonly endA: Endpoint;
   public readonly endB: Endpoint;
-  public readonly logger?: Logger;
+  public readonly logger: Logger;
 
   /**
    * findConnection attempts to reuse an existing Client/Connection.
@@ -235,7 +236,7 @@ export class Link {
   public constructor(endA: Endpoint, endB: Endpoint, logger?: Logger) {
     this.endA = endA;
     this.endB = endB;
-    this.logger = logger;
+    this.logger = logger ?? new NoopLogger();
   }
 
   /**
@@ -250,7 +251,7 @@ export class Link {
   public async updateClient(sender: Side): Promise<number> {
     const { src, dest } = this.getEnds(sender);
     const height = await dest.client.doUpdateClient(dest.clientID, src.client);
-    this.logger?.info(`Updated client for side ${sender} to height ${height}.`);
+    this.logger.info(`Updated client for side ${sender} to height ${height}.`);
     return height;
   }
 

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -249,9 +249,9 @@ export class Link {
    * Just needs trusting period on both side
    */
   public async updateClient(sender: Side): Promise<number> {
+    this.logger.info(`Updating client for side ${sender}.`);
     const { src, dest } = this.getEnds(sender);
     const height = await dest.client.doUpdateClient(dest.clientID, src.client);
-    this.logger.info(`Updated client for side ${sender} to height ${height}.`);
     return height;
   }
 
@@ -285,8 +285,10 @@ export class Link {
     ordering: Order,
     version: string
   ): Promise<ChannelPair> {
+    this.logger.info(
+      `Create channel with sender ${sender}: ${srcPort} => ${destPort}`
+    );
     const { src, dest } = this.getEnds(sender);
-
     // init on src
     const { channelId: channelIdSrc } = await src.client.channelOpenInit(
       srcPort,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,20 +1,37 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/* Logger interface with a subset of methods from winston.js */
+// From https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L53
+type LogCallback = (
+  error?: any,
+  level?: string,
+  message?: string,
+  meta?: any
+) => void;
+
+// From https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L69-L75
+export interface LeveledLogMethod {
+  (message: string, callback: LogCallback): Logger;
+  (message: string, meta: any, callback: LogCallback): Logger;
+  (message: string, ...meta: any[]): Logger;
+  (message: any): Logger;
+  (infoObject: Record<string, unknown>): Logger;
+}
+
+// Logger interface with a subset of methods from https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L107-L115
 export interface Logger {
-  error: (message: string, ...meta: any[]) => Logger;
-  warn: (message: string, ...meta: any[]) => Logger;
-  info: (message: string, ...meta: any[]) => Logger;
-  verbose: (message: string, ...meta: any[]) => Logger;
-  debug: (message: string, ...meta: any[]) => Logger;
+  error: LeveledLogMethod;
+  warn: LeveledLogMethod;
+  info: LeveledLogMethod;
+  verbose: LeveledLogMethod;
+  debug: LeveledLogMethod;
 }
 
 export class NoopLogger implements Logger {
-  public readonly error: (message: string, ...meta: any[]) => Logger;
-  public readonly warn: (message: string, ...meta: any[]) => Logger;
-  public readonly info: (message: string, ...meta: any[]) => Logger;
-  public readonly verbose: (message: string, ...meta: any[]) => Logger;
-  public readonly debug: (message: string, ...meta: any[]) => Logger;
+  public readonly error: LeveledLogMethod;
+  public readonly warn: LeveledLogMethod;
+  public readonly info: LeveledLogMethod;
+  public readonly verbose: LeveledLogMethod;
+  public readonly debug: LeveledLogMethod;
 
   constructor() {
     this.error = () => this;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/* Logger interface with a subset of methods from winston.js */
+export interface Logger {
+  error: (message: string, ...meta: any[]) => Logger;
+  warn: (message: string, ...meta: any[]) => Logger;
+  info: (message: string, ...meta: any[]) => Logger;
+  verbose: (message: string, ...meta: any[]) => Logger;
+  debug: (message: string, ...meta: any[]) => Logger;
+}
+
+export class NoopLogger implements Logger {
+  public readonly error: (message: string, ...meta: any[]) => Logger;
+  public readonly warn: (message: string, ...meta: any[]) => Logger;
+  public readonly info: (message: string, ...meta: any[]) => Logger;
+  public readonly verbose: (message: string, ...meta: any[]) => Logger;
+  public readonly debug: (message: string, ...meta: any[]) => Logger;
+
+  constructor() {
+    this.error = () => this;
+    this.warn = () => this;
+    this.info = () => this;
+    this.verbose = () => this;
+    this.debug = () => this;
+  }
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,37 +1,26 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-// From https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L53
-type LogCallback = (
-  error?: any,
-  level?: string,
-  message?: string,
-  meta?: any
-) => void;
-
-// From https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L69-L75
-export interface LeveledLogMethod {
-  (message: string, callback: LogCallback): Logger;
-  (message: string, meta: any, callback: LogCallback): Logger;
-  (message: string, ...meta: any[]): Logger;
-  (message: any): Logger;
-  (infoObject: Record<string, unknown>): Logger;
-}
+// Adapted from https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L69-L75
+export type LogMethod = (
+  /* The string to be logged */
+  message: string,
+  /* Optional object to be JSON-stringified by the logger */
+  meta?: Record<string, unknown>
+) => Logger;
 
 // Logger interface with a subset of methods from https://github.com/winstonjs/winston/blob/v3.3.3/index.d.ts#L107-L115
 export interface Logger {
-  error: LeveledLogMethod;
-  warn: LeveledLogMethod;
-  info: LeveledLogMethod;
-  verbose: LeveledLogMethod;
-  debug: LeveledLogMethod;
+  error: LogMethod;
+  warn: LogMethod;
+  info: LogMethod;
+  verbose: LogMethod;
+  debug: LogMethod;
 }
 
 export class NoopLogger implements Logger {
-  public readonly error: LeveledLogMethod;
-  public readonly warn: LeveledLogMethod;
-  public readonly info: LeveledLogMethod;
-  public readonly verbose: LeveledLogMethod;
-  public readonly debug: LeveledLogMethod;
+  public readonly error: LogMethod;
+  public readonly warn: LogMethod;
+  public readonly info: LogMethod;
+  public readonly verbose: LogMethod;
+  public readonly debug: LogMethod;
 
   constructor() {
     this.error = () => this;

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -5,10 +5,30 @@ import { Decimal } from '@cosmjs/math';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { StargateClient } from '@cosmjs/stargate';
 import test from 'ava';
+import sinon from 'sinon';
 
 import { Order } from '../codec/ibc/core/channel/v1/channel';
 
 import { IbcClient, IbcClientOptions } from './ibcclient';
+import { Logger } from './utils';
+
+export class TestLogger implements Logger {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  public readonly error: (message: string, ...meta: any[]) => Logger;
+  public readonly warn: (message: string, ...meta: any[]) => Logger;
+  public readonly info: (message: string, ...meta: any[]) => Logger;
+  public readonly verbose: (message: string, ...meta: any[]) => Logger;
+  public readonly debug: (message: string, ...meta: any[]) => Logger;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  constructor() {
+    this.error = sinon.fake.returns(this);
+    this.warn = sinon.fake.returns(this);
+    this.info = sinon.fake.returns(this);
+    this.verbose = sinon.fake.returns(this);
+    this.debug = sinon.fake.returns(this);
+  }
+}
 
 export const simapp = {
   tendermintUrlWs: 'ws://localhost:26658',

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -10,7 +10,7 @@ import sinon, { SinonSpy } from 'sinon';
 import { Order } from '../codec/ibc/core/channel/v1/channel';
 
 import { IbcClient, IbcClientOptions } from './ibcclient';
-import { Logger } from './utils';
+import { Logger } from './logger';
 
 export class TestLogger implements Logger {
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/lib/testutils.spec.ts
+++ b/src/lib/testutils.spec.ts
@@ -13,18 +13,16 @@ import { IbcClient, IbcClientOptions } from './ibcclient';
 import { Logger } from './logger';
 
 export class TestLogger implements Logger {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
   public readonly error: SinonSpy &
-    ((message: string, ...meta: any[]) => Logger);
+    ((message: string, meta?: Record<string, unknown>) => Logger);
   public readonly warn: SinonSpy &
-    ((message: string, ...meta: any[]) => Logger);
+    ((message: string, meta?: Record<string, unknown>) => Logger);
   public readonly info: SinonSpy &
-    ((message: string, ...meta: any[]) => Logger);
+    ((message: string, meta?: Record<string, unknown>) => Logger);
   public readonly verbose: SinonSpy &
-    ((message: string, ...meta: any[]) => Logger);
+    ((message: string, meta?: Record<string, unknown>) => Logger);
   public readonly debug: SinonSpy &
-    ((message: string, ...meta: any[]) => Logger);
-  /* eslint-enable @typescript-eslint/no-explicit-any */
+    ((message: string, meta?: Record<string, unknown>) => Logger);
 
   constructor() {
     this.error = sinon.fake.returns(this);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,17 +18,6 @@ import {
 } from '../codec/ibc/lightclients/tendermint/v1/tendermint';
 import { PublicKey as ProtoPubKey } from '../codec/tendermint/crypto/keys';
 
-// Subset of methods from winston.js
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export interface Logger {
-  error: (message: string, ...meta: any[]) => Logger;
-  warn: (message: string, ...meta: any[]) => Logger;
-  info: (message: string, ...meta: any[]) => Logger;
-  verbose: (message: string, ...meta: any[]) => Logger;
-  debug: (message: string, ...meta: any[]) => Logger;
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
 export interface Ack {
   readonly acknowledgement: Uint8Array;
   readonly originalPacket: Packet;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,6 +18,17 @@ import {
 } from '../codec/ibc/lightclients/tendermint/v1/tendermint';
 import { PublicKey as ProtoPubKey } from '../codec/tendermint/crypto/keys';
 
+// Subset of methods from winston.js
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface Logger {
+  error: (message: string, ...meta: any[]) => Logger;
+  warn: (message: string, ...meta: any[]) => Logger;
+  info: (message: string, ...meta: any[]) => Logger;
+  verbose: (message: string, ...meta: any[]) => Logger;
+  debug: (message: string, ...meta: any[]) => Logger;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 export interface Ack {
   readonly acknowledgement: Uint8Array;
   readonly originalPacket: Packet;


### PR DESCRIPTION
Part 1 of #57

Here's my first attempt:
- Pass the logger to the relevant constructor (must be handled separately for `Link` and `IbcClient` because the clients are created before the link is)
- Make it optional
- Use spies for testing (ava doesn't seem to have built-in spies so I just used sinon)
- Does `Endpoint` really need logging? It seems like all it does is pass something down to the client which will also log
- `.logger` is a public property for ease of testing, but we could make it private and open it up in the tests