### PR TITLE
Use yarn.lock for cache checksum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      # - run: yarn install
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-      - run: yarn install
-      # TODO: enable this when we check in yarn.lock
-      # - run: yarn install --frozen-lockfile
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+      - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - ~/.cache/yarn
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn build
       - run: yarn test:lint
       - run: yarn test:prettier
@@ -65,14 +63,13 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            # - yarn-packages-{{ checksum "yarn.lock" }}
-            - yarn-packages-{{ checksum "package.json" }}
-      - run: yarn install
-      # - run: yarn install --frozen-lockfile
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      # - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-packages-{{ checksum "package.json" }}
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,10 @@ jobs:
           command: |
             curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
             sudo apt-get install -y nodejs
-      # - run:
-      #     name: Install yarn
-      #     command: |
-      #       sudo chown -R $USER /usr/lib/node_modules
-      #       sudo chown -R $USER /usr/bin
-      #       npm i -g yarn
+      - run:
+          name: Set yarn version to latest stable
+          command: |
+            yarn set version latest
       - run:
           name: Version information
           command: echo "node $(node --version)"; echo "yarn $(yarn --version)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - run:
           name: Install yarn
           command: |
+            sudo chown -R $USER /usr/lib/node_modules
             npm i -g yarn
       - run:
           name: Version information

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
           name: Install yarn
           command: |
             sudo chown -R $USER /usr/lib/node_modules
+            sudo chown -R $USER /usr/bin
             npm i -g yarn
       - run:
           name: Version information

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,7 @@ jobs:
       - run:
           name: Install yarn
           command: |
-            curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update && sudo apt-get install -y yarn
+            npm i -g yarn
       - run:
           name: Version information
           command: echo "node $(node --version)"; echo "yarn $(yarn --version)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ jobs:
           command: |
             curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
             sudo apt-get install -y nodejs
-      - run:
-          name: Install yarn
-          command: |
-            sudo chown -R $USER /usr/lib/node_modules
-            sudo chown -R $USER /usr/bin
-            npm i -g yarn
+      # - run:
+      #     name: Install yarn
+      #     command: |
+      #       sudo chown -R $USER /usr/lib/node_modules
+      #       sudo chown -R $USER /usr/bin
+      #       npm i -g yarn
       - run:
           name: Version information
           command: echo "node $(node --version)"; echo "yarn $(yarn --version)"


### PR DESCRIPTION
- use `yarn.lock` for the checksum cache
- replace `install yarn` step with `set yarn version to latest stable` since `yarn` comes preinstalled on the machine we're using (speeds up the running time by 11 seconds 🚀 😅)