### PR TITLE
46 upgrade wasmd 0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/ibcclient.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/ibcclient.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/scripts/wasmd/env
+++ b/scripts/wasmd/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/cosmwasm/wasmd/tags
 REPOSITORY="cosmwasm/wasmd"
-VERSION="v0.15.1"
+VERSION="v0.16.0-alpha1"
 
 CONTAINER_NAME="wasmd"

--- a/scripts/wasmd/start.sh
+++ b/scripts/wasmd/start.sh
@@ -32,4 +32,4 @@ docker run --rm \
   --mount type=volume,source=wasmd_data,target=/root \
   "$REPOSITORY:$VERSION" \
   ./run_wasmd.sh /template \
-  2>&1 | grep 'Executed block'
+  2>&1 | grep 'executed block'

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -49,10 +49,6 @@ test.serial('create and update wasmd client on simapp', async (t) => {
   const [src, dest] = await setup();
 
   const header = await src.latestHeader();
-  // add some checks here as it randomly fails with "header from the future"
-  console.log('first header time', header.time);
-  const remoteHeader1 = await dest.latestHeader();
-  console.log('remote header time', remoteHeader1.time);
 
   const conState = buildConsensusState(header);
   const cliState = buildClientState(
@@ -74,10 +70,6 @@ test.serial('create and update wasmd client on simapp', async (t) => {
   const newHeight = newHeader.signedHeader?.header?.height;
   t.not(newHeight?.toNumber(), header.height);
 
-  // add some checks here as it randomly fails with "header from the future"
-  console.log('new header time', newHeader.signedHeader?.header?.time);
-  const remoteHeader2 = await dest.latestHeader();
-  console.log('remote header time', remoteHeader2.time);
   await dest.updateTendermintClient(clientId, newHeader);
 
   // any other checks?

--- a/src/lib/ibcclient.spec.ts
+++ b/src/lib/ibcclient.spec.ts
@@ -160,7 +160,7 @@ test.serial('perform connection handshake', async (t) => {
     destClientId,
     srcConnId
   );
-  await dest.connOpenConfirm(proofConfirm);
+  await dest.connOpenConfirm(destConnId, proofConfirm);
 });
 
 test.serial('transfer message and send packets', async (t) => {

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -863,15 +863,19 @@ export class IbcClient {
   }
 
   public async connOpenConfirm(
+    myConnectionId: string,
     proof: ConnectionHandshakeProof
   ): Promise<MsgResult> {
+    console.log(
+      `Connection open confirm: ${proof.connectionId} (my: ${myConnectionId})`
+    );
     this.logger.info(`Connection open confirm: ${proof.connectionId}`);
     const senderAddress = this.senderAddress;
-    const { connectionId, proofHeight, proofConnection: proofAck } = proof;
+    const { proofHeight, proofConnection: proofAck } = proof;
     const msg = {
       typeUrl: '/ibc.core.connection.v1.MsgConnectionOpenConfirm',
       value: MsgConnectionOpenConfirm.fromPartial({
-        connectionId,
+        connectionId: myConnectionId,
         signer: senderAddress,
         proofHeight,
         proofAck,

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -866,10 +866,7 @@ export class IbcClient {
     myConnectionId: string,
     proof: ConnectionHandshakeProof
   ): Promise<MsgResult> {
-    console.log(
-      `Connection open confirm: ${proof.connectionId} (my: ${myConnectionId})`
-    );
-    this.logger.info(`Connection open confirm: ${proof.connectionId}`);
+    this.logger.info(`Connection open confirm: ${myConnectionId}`);
     const senderAddress = this.senderAddress;
     const { proofHeight, proofConnection: proofAck } = proof;
     const msg = {

--- a/src/lib/link.spec.ts
+++ b/src/lib/link.spec.ts
@@ -192,7 +192,7 @@ test.serial(
       ics20.destPortId,
       { portId: ics20.srcPortId, channelId: srcChannelId },
       ics20.ordering,
-      connA,
+      connB,
       ics20.version,
       ics20.version,
       proof

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -239,6 +239,7 @@ export class Link {
       clientIdA,
       clientIdB
     );
+    console.log(`Clients: ${clientIdA} - ${clientIdB}`);
 
     // connectionTry on nodeB
     const proof = await prepareConnectionHandshake(
@@ -249,6 +250,7 @@ export class Link {
       connIdA
     );
     const { connectionId: connIdB } = await nodeB.connOpenTry(clientIdB, proof);
+    console.log(`Connections: ${connIdA} - ${connIdB}`);
 
     // connectionAck on nodeA
     const proofAck = await prepareConnectionHandshake(
@@ -268,7 +270,7 @@ export class Link {
       clientIdB,
       connIdA
     );
-    await nodeB.connOpenConfirm(proofConfirm);
+    await nodeB.connOpenConfirm(connIdB, proofConfirm);
 
     const endA = new Endpoint(nodeA, clientIdA, connIdA);
     const endB = new Endpoint(nodeB, clientIdB, connIdB);
@@ -405,7 +407,7 @@ export class Link {
       destPort,
       { portId: srcPort, channelId: channelIdSrc },
       ordering,
-      src.connectionID,
+      dest.connectionID,
       version,
       version,
       proof

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -239,7 +239,6 @@ export class Link {
       clientIdA,
       clientIdB
     );
-    console.log(`Clients: ${clientIdA} - ${clientIdB}`);
 
     // connectionTry on nodeB
     const proof = await prepareConnectionHandshake(
@@ -250,7 +249,6 @@ export class Link {
       connIdA
     );
     const { connectionId: connIdB } = await nodeB.connOpenTry(clientIdB, proof);
-    console.log(`Connections: ${connIdA} - ${connIdB}`);
 
     // connectionAck on nodeA
     const proofAck = await prepareConnectionHandshake(


### PR DESCRIPTION
Preparation for #46 

Update wasmd to `v0.16.0-alpha1`.

Along the way, I was running a simapp chain ~50 clients/connections ahead of the wasmd chain and I found a few places where that failed due to mixing up dest/src connectionIds. I fixed all those places and we should be better.