### PR TITLE
Add faucet support to ibc-setup init

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Now you should see an updated balance, and can make an ics20 channel:
 
 ```bash
 ibc-setup balances
-ibc-setup ics20 --dest-port custom
+ibc-setup ics20
 ```
 
 Now we have a channel, let's send some packets. Go back to [manual/consts.ts](./src/lib/manual/consts.ts)

--- a/demo/registry.yaml
+++ b/demo/registry.yaml
@@ -11,6 +11,8 @@ chains:
     hd_path: m/44'/108'/0'/1'
     # if you include an optional faucet, it will load the relayer with tokens in `ibc-setup init`
     faucet: https://faucet.musselnet.cosmwasm.com
+    # you can optionally define a default ics20_port that will be used instead of transfer if no flags set
+    ics20_port: 'transfer'
     # you can include multiple RPC endpoints and it will rotate through them if
     # one is down (TODO)
     rpc:
@@ -27,5 +29,6 @@ chains:
     prefix: cosmos
     gas_price: 0.025umuon
     hd_path: m/44'/108'/0'/3'
+    ics20_port: 'custom'
     rpc:
       - http://localhost:26658

--- a/demo/registry.yaml
+++ b/demo/registry.yaml
@@ -9,10 +9,12 @@ chains:
     gas_price: 0.025umayo
     # the path we use to derive the private key from the mnemonic
     hd_path: m/44'/108'/0'/1'
+    # if you include an optional faucet, it will load the relayer with tokens in `ibc-setup init`
+    faucet: https://faucet.musselnet.cosmwasm.com
     # you can include multiple RPC endpoints and it will rotate through them if
-    # one is down
+    # one is down (TODO)
     rpc:
-      - https://rpc.musselnet.cosmwasm.com:443
+      - https://rpc.musselnet.cosmwasm.com
   local_wasm:
     chain_id: testing
     prefix: wasm

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@cosmjs/crypto": "^0.24.0-alpha.26",
     "@cosmjs/encoding": "^0.24.0-alpha.26",
+    "@cosmjs/faucet-client": "^0.24.0-alpha.26",
     "@cosmjs/math": "^0.24.0-alpha.26",
     "@cosmjs/proto-signing": "^0.24.0-alpha.26",
     "@cosmjs/stargate": "^0.24.0-alpha.26",

--- a/src/binary/ibc-setup/commands/init.ts
+++ b/src/binary/ibc-setup/commands/init.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
+import { FaucetClient } from '@cosmjs/faucet-client';
 import axios from 'axios';
 import yaml from 'js-yaml';
 
 import { appFile, registryFile } from '../../constants';
+import { feeDenom } from '../../types';
 import { deriveAddress } from '../../utils/derive-address';
 import { generateMnemonic } from '../../utils/generate-mnemonic';
 import { getDefaultHomePath } from '../../utils/get-default-home-path';
@@ -97,4 +99,16 @@ export async function run(options: Options) {
   ]);
   console.log(`Source address: ${addressSrc}`);
   console.log(`Destination address: ${addressDest}`);
+
+  // if there are faucets, ask for tokens
+  if (chainSrc.faucet) {
+    const srcDenom = feeDenom(chainSrc);
+    console.log(`Requesting ${srcDenom} for ${chainSrc.chain_id}...`);
+    await new FaucetClient(chainSrc.faucet).credit(addressSrc, srcDenom);
+  }
+  if (chainDest.faucet) {
+    const destDenom = feeDenom(chainDest);
+    console.log(`Requesting ${destDenom} for ${chainDest.chain_id}...`);
+    await new FaucetClient(chainDest.faucet).credit(addressDest, destDenom);
+  }
 }

--- a/src/binary/types.ts
+++ b/src/binary/types.ts
@@ -4,6 +4,7 @@ export type Chain = {
   chain_id: string;
   prefix: string;
   gas_price: string;
+  faucet?: string;
   hd_path?: string;
   rpc: string[];
 };

--- a/src/binary/types.ts
+++ b/src/binary/types.ts
@@ -6,6 +6,7 @@ export type Chain = {
   gas_price: string;
   faucet?: string;
   hd_path?: string;
+  ics20_port?: string;
   rpc: string[];
 };
 

--- a/src/binary/utils/load-and-validate-registry.ts
+++ b/src/binary/utils/load-and-validate-registry.ts
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 import { registryFile } from '../constants';
 import { Registry } from '../types';
 
-export function loadAndValidateRegistry(filepath: string) {
+export function loadAndValidateRegistry(filepath: string): Registry {
   const registry = yaml.load(fs.readFileSync(filepath, 'utf-8'));
 
   const ajv = new Ajv({ allErrors: true });
@@ -33,6 +33,7 @@ export function loadAndValidateRegistry(filepath: string) {
               chain_id: { type: 'string' },
               prefix: { type: 'string' },
               gas_price: { type: 'string' },
+              faucet: { type: 'string', nullable: true },
               hd_path: { type: 'string', nullable: true },
               rpc: { type: 'array', items: { type: 'string' }, minItems: 1 },
             },

--- a/src/binary/utils/load-and-validate-registry.ts
+++ b/src/binary/utils/load-and-validate-registry.ts
@@ -35,6 +35,7 @@ export function loadAndValidateRegistry(filepath: string): Registry {
               gas_price: { type: 'string' },
               faucet: { type: 'string', nullable: true },
               hd_path: { type: 'string', nullable: true },
+              ics20_port: { type: 'string', nullable: true },
               rpc: { type: 'array', items: { type: 'string' }, minItems: 1 },
             },
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,6 +266,13 @@
     bech32 "^1.1.4"
     readonly-date "^1.0.0"
 
+"@cosmjs/faucet-client@^0.24.0-alpha.26":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cosmjs/faucet-client/-/faucet-client-0.24.0.tgz#20996db54a2b4d4674ebd79943084a5be7dae16c"
+  integrity sha512-9ksOirROoUY/R9dwcqX4gPn8uLiVbxwOXtXJWvjsfDqTXnghReANC2lbSt7efcMRNbaZOf3FZRLDKDOegfO63w==
+  dependencies:
+    axios "^0.21.1"
+
 "@cosmjs/json-rpc@^0.24.0-alpha.26":
   version "0.24.0-alpha.26"
   resolved "https://registry.yarnpkg.com/@cosmjs/json-rpc/-/json-rpc-0.24.0-alpha.26.tgz#9897a671222014292f46739cfa57ec6a34b5da99"


### PR DESCRIPTION
Closes #107

* Add faucet to registry and hit in `ibc-setup init`
* Add ics20_port to registry (and use as default for chain if none provided)