### PR TITLE
Properly calculate multiplied fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:lint": "eslint src --ext .ts",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc --silent ava --serial",
-    "focused-test": "run-s build && yarn test:unit ./src/lib/link.spec.ts",
+    "focused-test": "run-s build && yarn test:unit ./src/lib/utils.spec.ts",
     "check-cli": "run-s test diff-integration-tests check-integration-tests",
     "check-integration-tests": "run-s check-integration-test:*",
     "diff-integration-tests": "mkdir -p diff && rm -rf diff/test && cp -r test diff/test && rm -rf diff/test/test-*/.git && cd diff && git init --quiet && git add -A && git commit --quiet --no-verify --allow-empty -m 'WIP' && echo '\\n\\nCommitted most recent integration test output in the \"diff\" directory. Review the changes with \"cd diff && git diff HEAD\" or your preferred git diff viewer.'",

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -352,15 +352,12 @@ export class IbcClient {
     await sleep(50);
   }
 
-  public async getCommit(height?: number): Promise<CommitResponse> {
-    if (height === undefined) {
-      this.logger.verbose('Get latest commit');
-      const latestHeader = await this.latestHeader();
-      await this.waitOneBlock();
-      return this.tm.commit(latestHeader.height);
-    }
-
-    this.logger.verbose(`Get commit for height ${height}`);
+  public getCommit(height?: number): Promise<CommitResponse> {
+    this.logger.verbose(
+      height === undefined
+        ? 'Get latest commit'
+        : `Get commit for height ${height}`
+    );
     return this.tm.commit(height);
   }
 

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { parseRevisionNumber } from './utils';
+import { multiplyCoin, multiplyFees, parseRevisionNumber } from './utils';
 
 test('can parse revision numbers', (t) => {
   const musselnet = parseRevisionNumber('musselnet-4');
@@ -31,4 +31,29 @@ test('can parse strange revision numbers', (t) => {
     const rev = parseRevisionNumber(strange);
     t.is(rev.toNumber(), 0, strange);
   }
+});
+
+test('properly multiplies coin', (t) => {
+  const input = { amount: '1212', denom: 'foo' };
+  const output = multiplyCoin(input, 3);
+  t.deepEqual(output, { amount: '3636', denom: 'foo' });
+
+  const input2 = { amount: '654321', denom: 'umuon' };
+  const output2 = multiplyCoin(input2, 2);
+  t.deepEqual(output2, { amount: '1308642', denom: 'umuon' });
+});
+
+test('properly multiplies fees', (t) => {
+  const input = {
+    gas: '12345',
+    amount: [
+      {
+        amount: '654321',
+        denom: 'umuon',
+      },
+    ],
+  };
+  const out = multiplyFees(input, 2);
+  t.deepEqual(out.gas, '24690');
+  t.deepEqual(out.amount, [{ amount: '1308642', denom: 'umuon' }]);
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -301,11 +301,12 @@ export function parseAck({ type, attributes }: ParsedEvent): Ack {
 
 export function multiplyFees({ gas, amount }: StdFee, mult: number): StdFee {
   const multGas = Number.parseInt(gas, 10) * mult;
-  const multAmount = amount.map(multiplyCoin, mult);
-  return {
+  const multAmount = amount.map((c) => multiplyCoin(c, mult));
+  const result = {
     gas: multGas.toString(),
     amount: multAmount,
   };
+  return result;
 }
 
 export function multiplyCoin({ amount, denom }: Coin, mult: number): Coin {


### PR DESCRIPTION
This was always multiplying the fees to 0, but that was okay, since the CI networks enforced no minimum fees.
Fix some (1 month old, untested logic) and now the connections work.

Also reverts the (now unneeded after #115) fix to get latest commit