### PR TITLE
fix: Support chains with more than 100 active validators

### DIFF
--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -402,7 +402,7 @@ export class IbcClient {
     this.logger.verbose(`Get validator set for height ${height}`);
     // we need to query the header to find out who the proposer was, and pull them out
     const { proposerAddress } = await this.header(height);
-    const validators = await this.tm.validators({ height });
+    const validators = await this.tm.validatorsAll( height );
     const mappedValidators = validators.validators.map((val) => ({
       address: val.address,
       pubKey: mapRpcPubKeyToProto(val.pubkey),

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -402,7 +402,7 @@ export class IbcClient {
     this.logger.verbose(`Get validator set for height ${height}`);
     // we need to query the header to find out who the proposer was, and pull them out
     const { proposerAddress } = await this.header(height);
-    const validators = await this.tm.validatorsAll( height );
+    const validators = await this.tm.validatorsAll(height);
     const mappedValidators = validators.validators.map((val) => ({
       address: val.address,
       pubKey: mapRpcPubKeyToProto(val.pubkey),


### PR DESCRIPTION
getValidatorSet() uses the paged validators() query which has a limit of 100 entries.

Switching to the validatorsAll() query will ensure hashes match on networks with more than 100 active validators such as Cosmos Hub