### PR TITLE
Add missing await for run

### DIFF
--- a/src/binary/ibc-setup/commands/ics20.ts
+++ b/src/binary/ibc-setup/commands/ics20.ts
@@ -113,7 +113,7 @@ export async function ics20(flags: Flags, logger: Logger): Promise<void> {
   );
   const connections = resolveConnections(app);
 
-  run(
+  await run(
     {
       src,
       dest,


### PR DESCRIPTION
This should fix the `UnhandledPromiseRejectionWarning` from #180 by ensuring that `run`'s errors are propagated properly.