### PR TITLE
Add home option to ics20 command

### DIFF
--- a/.changeset/good-dancers-yell.md
+++ b/.changeset/good-dancers-yell.md
@@ -1,0 +1,5 @@
+---
+'@confio/relayer': patch
+---
+
+Add home option to ics20 command

--- a/src/binary/ibc-setup/index.ts
+++ b/src/binary/ibc-setup/index.ts
@@ -58,6 +58,7 @@ const ics20Command = program
   .description(
     'Create new unordered channel (ics20-1) for given chains, ports, and connections'
   )
+  .addOption(homeOption)
   .addOption(srcTrust)
   .addOption(destTrust)
   .addOption(mnemonicOption)


### PR DESCRIPTION
Fix the `error: unknown option '--home'` error on `ibc-setup ics20` for the case where `ibc-setup init...` was run with the `--home` option.