### PR TITLE
Wait for indexer instead of whole block

### DIFF
--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -538,8 +538,8 @@ export class Link {
 
     // let's wait a bit to ensure our newly committed acks are indexed
     await Promise.all([
-      this.endA.client.waitOneBlock(),
-      this.endB.client.waitOneBlock(),
+      this.endA.client.waitForIndexer(),
+      this.endB.client.waitForIndexer(),
     ]);
 
     const [ackHeightA, ackHeightB, acksA, acksB] = await Promise.all([


### PR DESCRIPTION
Using `waitOneBlock` is very heavy since it always waits a whole blocktime. If we are a bit out of luck with the node, it sends 3 requests per chain and sleeps for 2 blocktimes. But here we don't need a new block but only get indexed for what we have a DeliverTxResponse already.