### PR TITLE
Bump TypeScript build target to es2018 (same as CosmJS)

### DIFF
--- a/.changeset/little-beans-fry.md
+++ b/.changeset/little-beans-fry.md
@@ -1,0 +1,5 @@
+---
+'@confio/relayer': patch
+---
+
+Bump TypeScript build target to es2018 (same as CosmJS)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2018",
     "lib": ["es2020"],
     "moduleResolution": "node",
     "incremental": true,


### PR DESCRIPTION
to get more modern JavaScript output.

No more `__awaiter` code like this:

```js
"use strict";
var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
    return new (P || (P = Promise))(function (resolve, reject) {
        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
        step((generator = generator.apply(thisArg, _arguments || [])).next());
    });
};
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
Object.defineProperty(exports, "__esModule", { value: true });
```