### PR TITLE
Fix Uint8Array to string conversion in parsePacketsFromBlockResult

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -194,10 +194,6 @@ interface ParsedEvent {
   readonly attributes: readonly ParsedAttribute[];
 }
 
-function decodeBase64(value: Uint8Array): string {
-  return Buffer.from(value).toString('binary');
-}
-
 export function parsePacketsFromBlockResult(
   result: BlockResultsResponse
 ): Packet[] {
@@ -207,8 +203,8 @@ export function parsePacketsFromBlockResult(
     .map(({ type, attributes }) => ({
       type,
       attributes: attributes.map(({ key, value }) => ({
-        key: decodeBase64(key),
-        value: decodeBase64(value),
+        key: fromUtf8(key),
+        value: fromUtf8(value),
       })),
     }));
 


### PR DESCRIPTION
The code before was a binary to string converter:

```
Buffer.from(Uint8Array.from([0x60, 0x61, 0x62])).toString('binary')
'`ab'
```

However, according to https://nodejs.org/api/buffer.html "binary" is not an encoding that should be used

> 'binary': Alias for 'latin1'. See [binary strings](https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary) for more background on this topic. The name of this encoding can be very misleading, as all of the encodings listed here convert between strings and binary data. For converting between strings and Buffers, typically 'utf8' is the right choice.

So we did latin1 decoding instead of utf-8, such that this probably only worked for the 7 bit ASCII range.

Base64 is not used here at all.