### PR TITLE
Add txHash to AckWithMetadata

### DIFF
--- a/.changeset/rare-shoes-serve.md
+++ b/.changeset/rare-shoes-serve.md
@@ -1,0 +1,5 @@
+---
+"@confio/relayer": minor
+---
+
+Add txHash to AckWithMetadata

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -135,15 +135,15 @@ export class Endpoint {
     }
 
     const search = await this.client.tm.txSearchAll({ query });
-    const resultsNested = search.txs.map(({ height, result }) => {
+    const out = search.txs.flatMap(({ height, result }) => {
       const parsedLogs = logs.parseRawLog(result.log);
       // const sender = logs.findAttribute(parsedLogs, 'message', 'sender').value;
-      return parseAcksFromLogs(parsedLogs).map((ack) => ({
+      return parseAcksFromLogs(parsedLogs).map((ack): AckWithMetadata => ({
         height,
         ...ack,
       }));
     });
-    return ([] as AckWithMetadata[]).concat(...resultsNested);
+    return out;
   }
 }
 

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -1,3 +1,4 @@
+import { toHex } from '@cosmjs/encoding';
 import { logs } from '@cosmjs/stargate';
 import { tendermint34 } from '@cosmjs/tendermint-rpc';
 import { Packet } from 'cosmjs-types/ibc/core/channel/v1/channel';
@@ -19,6 +20,11 @@ export interface PacketWithMetadata {
 export type AckWithMetadata = Ack & {
   // block the ack was in, must query proofs >= height
   height: number;
+  /**
+   * The hash of the transaction in which the ack was found.
+   * Encoded as upper case hex.
+   */
+  txHash: string;
 };
 
 export interface QueryOpts {
@@ -135,13 +141,16 @@ export class Endpoint {
     }
 
     const search = await this.client.tm.txSearchAll({ query });
-    const out = search.txs.flatMap(({ height, result }) => {
+    const out = search.txs.flatMap(({ height, result, hash }) => {
       const parsedLogs = logs.parseRawLog(result.log);
       // const sender = logs.findAttribute(parsedLogs, 'message', 'sender').value;
-      return parseAcksFromLogs(parsedLogs).map((ack): AckWithMetadata => ({
-        height,
-        ...ack,
-      }));
+      return parseAcksFromLogs(parsedLogs).map(
+        (ack): AckWithMetadata => ({
+          height,
+          txHash: toHex(hash).toUpperCase(),
+          ...ack,
+        })
+      );
     });
     return out;
   }

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -727,13 +727,17 @@ export class Link {
     const proofs = await Promise.all(
       submit.map((packet) => src.client.getPacketProof(packet, headerHeight))
     );
-    const { logs, height } = await dest.client.receivePackets(
+    const { logs, height, transactionHash } = await dest.client.receivePackets(
       submit,
       proofs,
       headerHeight
     );
     const acks = parseAcksFromLogs(logs);
-    return acks.map((ack) => ({ height, ...ack }));
+    return acks.map((ack) => ({
+      height,
+      txHash: transactionHash,
+      ...ack,
+    }));
   }
 
   // this will update the client if needed and relay all provided acks from src -> dest


### PR DESCRIPTION
This is useful if you want to learn more about what happened in the ack, e.g. by querying the events of the transaction. We could also add the events directly, but the transaction hash is a bit simpler and more generic.