### PR TITLE
Add txEvents to AckWithMetadata

### DIFF
--- a/.changeset/violet-mugs-fold.md
+++ b/.changeset/violet-mugs-fold.md
@@ -1,0 +1,5 @@
+---
+"@confio/relayer": patch
+---
+
+Add txEvents to AckWithMetadata, allowing users to receive error messages of error acks

--- a/src/lib/endpoint.ts
+++ b/src/lib/endpoint.ts
@@ -1,5 +1,5 @@
 import { toHex } from '@cosmjs/encoding';
-import { fromTendermintEvent } from '@cosmjs/stargate';
+import { Event, fromTendermintEvent } from '@cosmjs/stargate';
 import { tendermint34 } from '@cosmjs/tendermint-rpc';
 import { Packet } from 'cosmjs-types/ibc/core/channel/v1/channel';
 
@@ -25,6 +25,11 @@ export type AckWithMetadata = Ack & {
    * Encoded as upper case hex.
    */
   txHash: string;
+  /**
+   * The events of the transaction in which the ack was found.
+   * Please note that the events do not necessarily belong to the ack.
+   */
+  txEvents: readonly Event[];
 };
 
 export interface QueryOpts {
@@ -148,6 +153,7 @@ export class Endpoint {
         (ack): AckWithMetadata => ({
           height,
           txHash: toHex(hash).toUpperCase(),
+          txEvents: events,
           ...ack,
         })
       );

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -733,6 +733,7 @@ export class Link {
     return acks.map((ack) => ({
       height,
       txHash: transactionHash,
+      txEvents: events,
       ...ack,
     }));
   }


### PR DESCRIPTION
This allows users to see the transaction's events in case of an error ack. Since the events is the recommended way to receive error ack details, this is needed as a basic functionality.