### PR TITLE
feat: Packet-level filtering

### DIFF
--- a/.changeset/witty-horses-watch.md
+++ b/.changeset/witty-horses-watch.md
@@ -1,0 +1,5 @@
+---
+'@confio/relayer': minor
+---
+
+Support for SDK 0.50.0 / CometBFT 0.38.0 and packet level filtering

--- a/.changeset/witty-horses-watch.md
+++ b/.changeset/witty-horses-watch.md
@@ -2,4 +2,4 @@
 '@confio/relayer': minor
 ---
 
-Support for SDK 0.50.0 / CometBFT 0.38.0 and packet level filtering
+Support for packet level filtering

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,6 @@
 export { AckWithMetadata, Endpoint } from './endpoint';
 export { IbcClient } from './ibcclient';
-export { Link, RelayInfo, RelayedHeights } from './link';
+export { Link, RelayInfo, RelayedHeights, PacketFilter } from './link';
 export { Logger, NoopLogger } from './logger';
 export * as testutils from './helpers';
 export { CosmWasmSigner } from './helpers';

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -38,7 +38,7 @@ export function otherSide(side: Side): Side {
   }
 }
 /**
- * PacketFilter is the type for a function that accepts a Packet and returns a boolean definign whether to relay the packet or not
+ * PacketFilter is the type for a function that accepts a Packet and returns a boolean defining whether to relay the packet or not
  */
 
 export type PacketFilter = (packet: Packet) => boolean;

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -37,10 +37,10 @@ export function otherSide(side: Side): Side {
     return 'A';
   }
 }
+
 /**
  * PacketFilter is the type for a function that accepts a Packet and returns a boolean defining whether to relay the packet or not
  */
-
 export type PacketFilter = (packet: Packet) => boolean;
 
 // This records the block heights from the last point where we successfully relayed packets.


### PR DESCRIPTION
This PR adds the option to only relay specific packets that are of interest to the app developer.

In order to avoid unnecessary development and maintenance overhead, the filtering mechanism is left entirely to the app developer.

This is achieved by defining a new function type: `PacketFilter` that takes a `Packet` as an argument and returns `true` if it should be relayed and `false` if it should be ignored.

Implementation of this function is left to the application developer and can be used by setting it via `link.setFilter(packetFilter: PacketFilter)`  on the `Link` instance. 

This PR also includes the complementary `Link.clearFilter()` method.