### PR TITLE
Fix header validation error

### DIFF
--- a/.changeset/thick-clouds-admire.md
+++ b/.changeset/thick-clouds-admire.md
@@ -2,4 +2,4 @@
 "@confio/relayer": patch
 ---
 
-fix header failed basic validation error
+fix header failed basic validation error for app version != 0

--- a/.changeset/thick-clouds-admire.md
+++ b/.changeset/thick-clouds-admire.md
@@ -1,0 +1,5 @@
+---
+"@confio/relayer": patch
+---
+
+fix header failed basic validation error

--- a/src/lib/ibcclient.ts
+++ b/src/lib/ibcclient.ts
@@ -368,6 +368,7 @@ export class IbcClient {
       ...rpcHeader,
       version: {
         block: BigInt(rpcHeader.version.block),
+        app: BigInt(rpcHeader.version.app),
       },
       height: BigInt(rpcHeader.height),
       time: timestampFromDateNanos(rpcHeader.time),


### PR DESCRIPTION
I think I solved the infamous `header failed basic validation` error!

```
Query failed with (6): rpc error: code = Unknown desc = header failed basic validation: commit signs block 333F5ECBE51CA88088C64523E7CF156A67695D949ABC23E02270FA57EF2D4269, header is block 444DB206D17B81B86392FCB24AF2162B956EBC5D7FBE367ACE3213545AAD926B [cosmos/ibc-go/v6@v6.2.0/modules/light-clients/07-tendermint/types/header.go:62] With gas wanted: '0' and gas used: '46662' : unknown request
```

It appears a field of the header was not being copied over correctly. Presumably it would succeed when `rpcHeader.version.app` was 0, and fail the rest of the time.